### PR TITLE
Step refactor (do not merge)

### DIFF
--- a/react/client/src/common/LinkedListNode.ts
+++ b/react/client/src/common/LinkedListNode.ts
@@ -1,0 +1,19 @@
+export interface LinkedListNodeProps {
+  next?: LinkedListNode;
+  prev?: LinkedListNode;
+  data: any;
+}
+
+export default class LinkedListNode {
+  next?: LinkedListNode;
+
+  prev?: LinkedListNode;
+
+  data: any;
+
+  constructor({ next, prev, data }: LinkedListNodeProps) {
+    this.next = next;
+    this.prev = prev;
+    this.data = data;
+  }
+}

--- a/react/client/src/components/Form.tsx
+++ b/react/client/src/components/Form.tsx
@@ -5,6 +5,8 @@ import { Theme, makeStyles, createStyles } from '@material-ui/core';
 
 import Button from 'components/Button';
 
+import { FORM_STEPS } from 'contexts/RoutingProps';
+
 import BeforeYouBegin from 'flows/BeforeYouBegin';
 import IntroductionStep from 'flows/IntroductionStep';
 import UnemployedStep from 'flows/UnemployedStep';
@@ -116,9 +118,11 @@ const Form = ({
 
   return (
     <div className={`${classes.root} content-page`}>
-      {pageNumber === 1 && <BeforeYouBegin goNextPage={goNextPage} />}
+      {formStep === FORM_STEPS.BEFORE_YOU_BEGIN && (
+        <BeforeYouBegin goNextPage={goNextPage} />
+      )}
 
-      {pageNumber === 2 && (
+      {formStep === FORM_STEPS.INTRODUCTION && (
         <IntroductionStep
           inputs={inputs}
           setInputs={setInputs}

--- a/react/client/src/components/Form.tsx
+++ b/react/client/src/components/Form.tsx
@@ -131,7 +131,7 @@ const Form = ({
         />
       )}
 
-      {pageNumber === 3 && (
+      {formStep === FORM_STEPS.INVOLVEMENT_GENERIC && (
         <InvolvementStep
           inputs={inputs}
           setInputs={setInputs}
@@ -140,7 +140,7 @@ const Form = ({
         />
       )}
 
-      {pageNumber === 4 && (
+      {formStep === FORM_STEPS.INTRODUCTION && (
         <UnemployedStep
           inputs={inputs}
           setInputs={setInputs}
@@ -149,7 +149,7 @@ const Form = ({
         />
       )}
 
-      {pageNumber === 5 && (
+      {formStep === FORM_STEPS.GOALS && (
         <GoalsStep
           inputs={inputs}
           setInputs={setInputs}
@@ -158,7 +158,7 @@ const Form = ({
         />
       )}
 
-      {pageNumber === 6 && (
+      {formStep === FORM_STEPS.WHY && (
         <WhyStep
           inputs={inputs}
           setInputs={setInputs}
@@ -167,20 +167,20 @@ const Form = ({
         />
       )}
 
-      {pageNumber === 7 && (
+      {formStep === FORM_STEPS.FINALIZE && (
         <div className={`${utilityClasses.buttonContainer} adjacent-mar-top`}>
           <p>Previewing Final Statement</p>
           <Button onClick={() => goBackPage()} buttonText="EDIT" />
           <Button onClick={() => goNextPage()} buttonText="NEXT" />
         </div>
       )}
-      {pageNumber === 8 && (
+      {formStep === FORM_STEPS.EDITING && (
         <div className={`${utilityClasses.buttonContainer} adjacent-mar-top`}>
           <p>Editing</p>
           <Button onClick={() => goNextPage()} buttonText="SAVE" />
         </div>
       )}
-      {pageNumber === 9 && (
+      {formStep === FORM_STEPS.DOWNLOAD && (
         <Download
           inputs={inputs}
           setInputs={setInputs}

--- a/react/client/src/components/Form.tsx
+++ b/react/client/src/components/Form.tsx
@@ -33,6 +33,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 interface FormProps {
   pageNumber: number;
+  formStep?: string;
   goNextPage: () => void;
   goBackPage: () => void;
   onChangeAffirmation: (newState: object) => void;
@@ -40,6 +41,7 @@ interface FormProps {
 
 const Form = ({
   pageNumber,
+  formStep,
   goNextPage,
   goBackPage,
   onChangeAffirmation,

--- a/react/client/src/components/PageContainer.tsx
+++ b/react/client/src/components/PageContainer.tsx
@@ -9,6 +9,7 @@ import Landing from 'pages/Landing';
 
 import { RoutingContext } from 'contexts/RoutingContext';
 import { AffirmationContext } from 'contexts/AffirmationContext';
+import { FORM_STEPS } from 'contexts/RoutingProps';
 
 interface styleProps {
   isLandingPage: boolean;
@@ -42,7 +43,7 @@ const PageContainer = ({ match }: PageProps) => {
 
   const { pageNumber, formStep, goNextPage, goBackPage } = useRoutingContext();
   const { affirmationData, updateAffirmationData } = useAffirmationContext();
-  const isLandingPage = pageNumber === 0;
+  const isLandingPage = formStep === null;
 
   const styleProps = { isLandingPage };
   const classes = useStyles(styleProps);

--- a/react/client/src/components/PageContainer.tsx
+++ b/react/client/src/components/PageContainer.tsx
@@ -40,7 +40,7 @@ const PageContainer = ({ match }: PageProps) => {
   const useRoutingContext = () => React.useContext(RoutingContext);
   const useAffirmationContext = () => React.useContext(AffirmationContext);
 
-  const { pageNumber, goNextPage, goBackPage } = useRoutingContext();
+  const { pageNumber, formStep, goNextPage, goBackPage } = useRoutingContext();
   const { affirmationData, updateAffirmationData } = useAffirmationContext();
   const isLandingPage = pageNumber === 0;
 
@@ -73,6 +73,7 @@ const PageContainer = ({ match }: PageProps) => {
       {!isLandingPage && (
         <Form
           pageNumber={pageNumber}
+          formStep={formStep}
           goNextPage={goNextPage}
           goBackPage={goBackPage}
           onChangeAffirmation={updateAffirmationData}

--- a/react/client/src/contexts/RoutingContext.tsx
+++ b/react/client/src/contexts/RoutingContext.tsx
@@ -1,25 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import {
-  withRouter,
-  RouteComponentProps,
-} from 'react-router-dom';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
 
-const FORM_STEPS = {
-  NONE: 'FORM_STEPS.NONE',
-  BEFORE_YOU_BEGIN: 'FORM_STEPS.BEFORE_YOU_BEGIN',
-  INTRODUCTION: 'FORM_STEPS.INTRODUCTION',
-  INVOLVEMENT: {
-    JOB: 'FORM_STEPS.INVOLVEMENT.JOB',
-    COMMUNITY_SERVICE: 'FORM_STEPS.INVOLVEMENT.COMMUNITY_SERVICE',
-    RECOVERY: 'FORM_STEPS.INVOLVEMENT.RECOVERY',
-    SCHOOL: 'FORM_STEPS.INVOLVEMENT.SCHOOL',
-    PARENTING: 'FORM_STEPS.INVOLVEMENT.PARENTING',
-    UNEMPLOYED: 'FORM_STEPS.INVOLVEMENT.UNEMPLOYED',
-  },
-  GOALS: 'FORM_STEPS.GOALS',
-  WHY: 'FORM_STEPS.WHY',
-  FINALIZE: 'FORM_STEPS.FINALIZE',
-}
+import { FORM_STEPS, initFormSteps } from 'contexts/RoutingProps';
 
 interface RoutingProviderProps extends RouteComponentProps<any> {
   children: React.ReactNode;
@@ -27,34 +9,45 @@ interface RoutingProviderProps extends RouteComponentProps<any> {
 
 export const RoutingContext = React.createContext<any>(undefined);
 
+const FormStepNode = initFormSteps();
+
 const RoutingContextProvider = ({
   children,
   history,
 }: RoutingProviderProps) => {
-  const [formStep, updateFormStep] = useState(FORM_STEPS.NONE);
+  const [stepNode, updateStepNode] = useState(FormStepNode);
 
   const url = history.location.pathname;
   const pageNumber = Number(url.slice(url.indexOf('/form') + 6)) || 0;
 
   const goNextPage = () => {
-    history.push(`/form/${pageNumber + 1}`);
+    const nextNode = stepNode.next;
+    if (nextNode !== undefined) {
+      updateStepNode(nextNode);
+      history.push(`/form/${nextNode.data.split('.')[1]}`);
+    }
   };
   const goBackPage = () => {
-    history.push(`/form/${pageNumber - 1}`);
+    // history.push(`/form/${pageNumber - 1}`);
+    const prevNode = stepNode.prev;
+    if (prevNode !== undefined) {
+      updateStepNode(prevNode);
+      history.push(`/form/${prevNode.data.split('.')[1]}`);
+    }
   };
 
-  useEffect(() => {
-    const isOnFormPage = url.indexOf('/form') >= 0;
-    if (!isOnFormPage) {
-      updateFormStep(FORM_STEPS.NONE);
-
-    } else if (isOnFormPage && formStep === FORM_STEPS.NONE) {
-      updateFormStep(FORM_STEPS.BEFORE_YOU_BEGIN);
-    }
-  }, [url])
+  // useEffect(() => {
+  //   const isOnFormPage = url.indexOf('/form') >= 0;
+  //   console.log('isOnFormPage', isOnFormPage)
+  //   if (isOnFormPage && stepNode.data === null) {
+  //     updateStepNode(initFormSteps());
+  //   }
+  // }, [url]);
 
   return (
-    <RoutingContext.Provider value={{ goNextPage, goBackPage, pageNumber, formStep }}>
+    <RoutingContext.Provider
+      value={{ goNextPage, goBackPage, pageNumber, formStep: stepNode.data }}
+    >
       {children}
     </RoutingContext.Provider>
   );

--- a/react/client/src/contexts/RoutingContext.tsx
+++ b/react/client/src/contexts/RoutingContext.tsx
@@ -44,6 +44,7 @@ const RoutingContextProvider = ({
   //   }
   // }, [url]);
 
+
   return (
     <RoutingContext.Provider
       value={{ goNextPage, goBackPage, pageNumber, formStep: stepNode.data }}

--- a/react/client/src/contexts/RoutingContext.tsx
+++ b/react/client/src/contexts/RoutingContext.tsx
@@ -1,5 +1,25 @@
-import React from 'react';
-import { withRouter, RouteComponentProps } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import {
+  withRouter,
+  RouteComponentProps,
+} from 'react-router-dom';
+
+const FORM_STEPS = {
+  NONE: 'FORM_STEPS.NONE',
+  BEFORE_YOU_BEGIN: 'FORM_STEPS.BEFORE_YOU_BEGIN',
+  INTRODUCTION: 'FORM_STEPS.INTRODUCTION',
+  INVOLVEMENT: {
+    JOB: 'FORM_STEPS.INVOLVEMENT.JOB',
+    COMMUNITY_SERVICE: 'FORM_STEPS.INVOLVEMENT.COMMUNITY_SERVICE',
+    RECOVERY: 'FORM_STEPS.INVOLVEMENT.RECOVERY',
+    SCHOOL: 'FORM_STEPS.INVOLVEMENT.SCHOOL',
+    PARENTING: 'FORM_STEPS.INVOLVEMENT.PARENTING',
+    UNEMPLOYED: 'FORM_STEPS.INVOLVEMENT.UNEMPLOYED',
+  },
+  GOALS: 'FORM_STEPS.GOALS',
+  WHY: 'FORM_STEPS.WHY',
+  FINALIZE: 'FORM_STEPS.FINALIZE',
+}
 
 interface RoutingProviderProps extends RouteComponentProps<any> {
   children: React.ReactNode;
@@ -11,6 +31,8 @@ const RoutingContextProvider = ({
   children,
   history,
 }: RoutingProviderProps) => {
+  const [formStep, updateFormStep] = useState(FORM_STEPS.NONE);
+
   const url = history.location.pathname;
   const pageNumber = Number(url.slice(url.indexOf('/form') + 6)) || 0;
 
@@ -21,8 +43,18 @@ const RoutingContextProvider = ({
     history.push(`/form/${pageNumber - 1}`);
   };
 
+  useEffect(() => {
+    const isOnFormPage = url.indexOf('/form') >= 0;
+    if (!isOnFormPage) {
+      updateFormStep(FORM_STEPS.NONE);
+
+    } else if (isOnFormPage && formStep === FORM_STEPS.NONE) {
+      updateFormStep(FORM_STEPS.BEFORE_YOU_BEGIN);
+    }
+  }, [url])
+
   return (
-    <RoutingContext.Provider value={{ goNextPage, goBackPage, pageNumber }}>
+    <RoutingContext.Provider value={{ goNextPage, goBackPage, pageNumber, formStep }}>
       {children}
     </RoutingContext.Provider>
   );

--- a/react/client/src/contexts/RoutingProps.ts
+++ b/react/client/src/contexts/RoutingProps.ts
@@ -16,6 +16,8 @@ export const FORM_STEPS = {
   GOALS: 'FORM_STEPS.GOALS',
   WHY: 'FORM_STEPS.WHY',
   FINALIZE: 'FORM_STEPS.FINALIZE',
+  EDITING: 'FORM_STEPS.EDITING',
+  DOWNLOAD: 'FORM_STEPS.DOWNLOAD',
 };
 
 /**
@@ -63,6 +65,18 @@ export function initFormSteps() {
     data: FORM_STEPS.FINALIZE,
   });
   WhyNode.next = FinalizeNode;
+
+  const EditingNode = new LinkedListNode({
+    prev: FinalizeNode,
+    data: FORM_STEPS.EDITING,
+  });
+  FinalizeNode.next = EditingNode;
+
+  const DownloadNode = new LinkedListNode({
+    prev: EditingNode,
+    data: FORM_STEPS.DOWNLOAD,
+  });
+  EditingNode.next = DownloadNode;
 
   return NullNode;
 }

--- a/react/client/src/contexts/RoutingProps.ts
+++ b/react/client/src/contexts/RoutingProps.ts
@@ -1,0 +1,66 @@
+import LinkedListNode from 'common/LinkedListNode';
+
+export const FORM_STEPS = {
+  NONE: 'FORM_STEPS.NONE',
+  BEFORE_YOU_BEGIN: 'FORM_STEPS.BEFORE_YOU_BEGIN',
+  INTRODUCTION: 'FORM_STEPS.INTRODUCTION',
+  INVOLVEMENT_GENERIC: 'FORM_STEPS.INVOLVEMENT_GENERIC',
+  INVOLVEMENT: {
+    JOB: 'FORM_STEPS.INVOLVEMENT.JOB',
+    COMMUNITY_SERVICE: 'FORM_STEPS.INVOLVEMENT.COMMUNITY_SERVICE',
+    RECOVERY: 'FORM_STEPS.INVOLVEMENT.RECOVERY',
+    SCHOOL: 'FORM_STEPS.INVOLVEMENT.SCHOOL',
+    PARENTING: 'FORM_STEPS.INVOLVEMENT.PARENTING',
+    UNEMPLOYED: 'FORM_STEPS.INVOLVEMENT.UNEMPLOYED',
+  },
+  GOALS: 'FORM_STEPS.GOALS',
+  WHY: 'FORM_STEPS.WHY',
+  FINALIZE: 'FORM_STEPS.FINALIZE',
+};
+
+/**
+ * @returns {LinkedListNode}
+ */
+export function initFormSteps() {
+  const NullNode = new LinkedListNode({
+    data: null,
+  });
+
+  const BeforeYouBeginNode = new LinkedListNode({
+    prev: NullNode,
+    data: FORM_STEPS.BEFORE_YOU_BEGIN,
+  });
+  NullNode.next = BeforeYouBeginNode;
+
+  const IntroductionNode = new LinkedListNode({
+    prev: BeforeYouBeginNode,
+    data: FORM_STEPS.INTRODUCTION,
+  });
+  BeforeYouBeginNode.next = IntroductionNode;
+
+  const InvolvementNode = new LinkedListNode({
+    prev: IntroductionNode,
+    data: FORM_STEPS.INVOLVEMENT_GENERIC,
+  });
+  IntroductionNode.next = InvolvementNode;
+
+  const GoalsNode = new LinkedListNode({
+    prev: InvolvementNode,
+    data: FORM_STEPS.GOALS,
+  });
+  InvolvementNode.next = GoalsNode;
+
+  const WhyNode = new LinkedListNode({
+    prev: GoalsNode,
+    data: FORM_STEPS.WHY,
+  });
+  GoalsNode.next = WhyNode;
+
+  const FinalizeNode = new LinkedListNode({
+    prev: WhyNode,
+    data: FORM_STEPS.FINALIZE,
+  });
+  WhyNode.next = FinalizeNode;
+
+  return NullNode;
+}

--- a/react/client/src/contexts/RoutingProps.ts
+++ b/react/client/src/contexts/RoutingProps.ts
@@ -19,6 +19,8 @@ export const FORM_STEPS = {
 };
 
 /**
+ * am I overengineering???
+ *
  * @returns {LinkedListNode}
  */
 export function initFormSteps() {


### PR DESCRIPTION
Yeah, so I was looking at the minor branching logic of the involvement step and how we would handle it based looking at the paths and tried to be a little clever with our navigation. This was an attempt but I do not like it. Posting it here to be discussed later along with a maybe more awkward alternative:
```
/**
 * @param {FORM_STEPS} step
 * @returns {FORM_STEPS}
 */
export function getNextFormStep(step: string) {
  switch (step) {
    case FORM_STEPS.NONE:
      return FORM_STEPS.BEFORE_YOU_BEGIN;

    case FORM_STEPS.BEFORE_YOU_BEGIN:
      return FORM_STEPS.INTRODUCTION;

    case FORM_STEPS.INTRODUCTION:
      return FORM_STEPS.INVOLVEMENT.JOB;

    case FORM_STEPS.INVOLVEMENT.JOB:
      return FORM_STEPS.INVOLVEMENT.COMMUNITY_SERVICE;

    case FORM_STEPS.INVOLVEMENT.COMMUNITY_SERVICE:
      return FORM_STEPS.INVOLVEMENT.RECOVERY;

    case FORM_STEPS.INVOLVEMENT.RECOVERY:
      return FORM_STEPS.INVOLVEMENT.SCHOOL;

    case FORM_STEPS.INVOLVEMENT.SCHOOL:
      return FORM_STEPS.INVOLVEMENT.PARENTING;

    case FORM_STEPS.INVOLVEMENT.PARENTING:
      return FORM_STEPS.INVOLVEMENT.UNEMPLOYED;

    case FORM_STEPS.INVOLVEMENT.UNEMPLOYED:
      return FORM_STEPS.GOALS;

    case FORM_STEPS.GOALS:
      return FORM_STEPS.WHY;

    case FORM_STEPS.WHY:
      return FORM_STEPS.FINALIZE;

    case FORM_STEPS.FINALIZE:
    default:
      return FORM_STEPS.NONE;
  }
}
```