### PR TITLE
Style Landing, BeforeYouBegin, Affirmation (mobile)

### DIFF
--- a/react/client/src/components/AffirmationComponent.tsx
+++ b/react/client/src/components/AffirmationComponent.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Theme, createStyles, makeStyles } from '@material-ui/core';
+import { Link } from 'react-router-dom';
 
 import AffirmationImage from 'assets/affirmation-img.svg';
+import iconBlack from 'assets/iconBlack.svg';
+
 import Button from './Button';
 
 const useStyles = makeStyles<Theme, StyleProps>(() =>
@@ -11,10 +14,10 @@ const useStyles = makeStyles<Theme, StyleProps>(() =>
       background: '#f7ebff',
       left: '0',
       bottom: '0',
-      top: '60px',
+      top: '0',
       width: '100%',
       color: '#3d0066',
-      padding: '24px',
+      padding: '18px',
       zIndex: 1,
       display: (props) => (props.isActive ? 'block' : 'none'),
     },
@@ -24,19 +27,19 @@ const useStyles = makeStyles<Theme, StyleProps>(() =>
       alignItems: 'center',
       justifyContent: 'center',
       maxWidth: '375px',
-      margin: '5rem auto 0',
+      margin: '4rem auto 0',
       position: 'relative',
     },
     cropIllustration: {
       overflow: 'hidden',
       position: 'absolute',
-      width: '348px',
+      width: '375px',
     },
     illustration: {
       width: '600px',
       position: 'relative',
-      left: '-111px',
-      top: '-12px',
+      left: '-78px',
+      top: '-3px',
     },
     messageContainer: {
       display: 'flex',
@@ -44,7 +47,7 @@ const useStyles = makeStyles<Theme, StyleProps>(() =>
       background: '#f7ebff',
       height: '350px',
       position: 'relative',
-      top: '277px',
+      top: '290px',
       paddingTop: '20px',
       borderTopRightRadius: '64px',
       minWidth: '375px',
@@ -53,7 +56,7 @@ const useStyles = makeStyles<Theme, StyleProps>(() =>
         content: '""',
         position: 'absolute',
         top: '-40px',
-        left: '8px',
+        left: '-4px',
         height: '40px',
         width: '40px',
         borderBottomLeftRadius: '200px',
@@ -87,6 +90,9 @@ const AffirmationComponent = ({
 
   return (
     <div className={classes.root}>
+      <Link to="/">
+        <img src={iconBlack} alt="Expunge Assist Logo" />
+      </Link>
       <div className={classes.container}>
         <div className={classes.cropIllustration}>
           <img
@@ -98,13 +104,14 @@ const AffirmationComponent = ({
 
         <div className={classes.messageContainer}>
           <div className="page-title adjacent-mar-top">{titleText}</div>
-          <div className="adjacent-mar-top">{description}</div>
+          <div style={{ marginTop: '16px' }}>{description}</div>
           <div
             style={{
               display: 'flex',
               justifyContent: 'flex-end',
+              marginTop: '39px',
             }}
-            className="adjacent-mar-top align-right-sm"
+            className="align-right-sm"
           >
             <Button
               onClick={() => onChangeAffirmation({ isActive: false })}

--- a/react/client/src/components/Header.tsx
+++ b/react/client/src/components/Header.tsx
@@ -61,7 +61,9 @@ const Header = ({ pageNumber }: HeaderProps) => {
 
   return (
     <div className={`${classes.root} app-header`}>
-      <img src={icon} alt="" />
+      <Link to="/">
+        <img src={icon} alt="" />
+      </Link>
       <Link
         to="/"
         style={{

--- a/react/client/src/components/Navbar.tsx
+++ b/react/client/src/components/Navbar.tsx
@@ -56,6 +56,10 @@ const useStyles = makeStyles((theme: Theme) =>
           fontSize: '1rem',
         },
       },
+      [theme.breakpoints.down('sm')]: {
+        position: 'relative',
+        bottom: '17px',
+      },
     },
   })
 );

--- a/react/client/src/flows/BeforeYouBegin.tsx
+++ b/react/client/src/flows/BeforeYouBegin.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { makeStyles, createStyles } from '@material-ui/core';
+
 import useUtilityStyles from 'styles/utilityStyles';
 import { useTranslation } from 'react-i18next';
 
@@ -8,16 +10,27 @@ interface ComponentProps {
   goNextPage: () => void;
 }
 
+const useStyles = makeStyles(() =>
+  createStyles({
+    content: {
+      margin: '23px 0 50px',
+    },
+  })
+);
 const BeforeYouBegin = ({ goNextPage }: ComponentProps) => {
+  const classes = useStyles();
   const utilityClasses = useUtilityStyles({});
   const { t } = useTranslation();
 
   return (
-    <>
-      <div className="adjacent-mar-top" style={{ fontWeight: 500 }}>
+    <div className={utilityClasses.contentContainer}>
+      <div
+        className="adjacent-mar-top"
+        style={{ fontWeight: 500, fontSize: '20px' }}
+      >
         {t('disclaimer.header')}
       </div>
-      <div className="adjacent-mar-top" style={{ whiteSpace: 'pre-line' }}>
+      <div className={classes.content} style={{ whiteSpace: 'pre-line' }}>
         {t('disclaimer.text')}
       </div>
 
@@ -28,7 +41,7 @@ const BeforeYouBegin = ({ goNextPage }: ComponentProps) => {
           hasArrow
         />
       </div>
-    </>
+    </div>
   );
 };
 

--- a/react/client/src/pages/Landing.tsx
+++ b/react/client/src/pages/Landing.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Button from 'components/Button';
+import { makeStyles, createStyles } from '@material-ui/core';
 
 import useUtilityStyles from 'styles/utilityStyles';
 
@@ -7,18 +8,29 @@ interface LandingProps {
   goNextPage: () => void;
 }
 
+const useStyles = makeStyles(() =>
+  createStyles({
+    marTop24: {
+      marginTop: '24px',
+    },
+    marTop36: {
+      marginTop: '36px',
+    },
+  })
+);
+
 const Landing = ({ goNextPage }: LandingProps) => {
+  const classes = useStyles();
   const utilityClasses = useUtilityStyles({ theme: 'dark' });
+
   return (
     <div className={`${utilityClasses.contentContainer} content-page`}>
-      <h1 className="page-title adjacent-mar-top">
-        Start fresh with a record expungement
-      </h1>
-      <div className="adjacent-mar-top">
+      <h1 className="page-title">Start fresh with a record expungement</h1>
+      <div className={classes.marTop24}>
         Generate a personal statement in just 20 minutes
       </div>
 
-      <div className={`${utilityClasses.buttonContainer} adjacent-mar-top`}>
+      <div className={`${utilityClasses.buttonContainer} ${classes.marTop36}`}>
         <Button
           onClick={() => goNextPage()}
           theme="dark"

--- a/react/client/src/styles/App.css
+++ b/react/client/src/styles/App.css
@@ -31,8 +31,7 @@ h2 {
   }
 }
 
-.app-header + .content-page,
-.page-title + .adjacent-mar-top {
+.app-header + .page-title + .adjacent-mar-top {
   margin-top: 15px;
 }
 

--- a/react/client/src/styles/utilityStyles.ts
+++ b/react/client/src/styles/utilityStyles.ts
@@ -16,6 +16,7 @@ const useUtilityStyles = makeStyles((theme) =>
       maxWidth: '850px',
       marginLeft: 'auto',
       marginRight: 'auto',
+      marginTop: '49px',
 
       [theme.breakpoints.down('xs')]: {
         marginLeft: 'initial',


### PR DESCRIPTION
-Made several spacing changes according to design specs
  -used a mix of inline styling and `makeStyles()` to replace some `adjacent-margin` classes that weren't spacing 100% correctly. Wasn't able to pick which was more elegant, let me know if you have a preference or, even a better solution
-Record clearance logo now acts as home button, redirecting user back to Landing
-Fixed Navbar links spacing on mobile (links were previously stuck to bottom without margin on mobile)


https://user-images.githubusercontent.com/35116846/113470582-82816000-940b-11eb-8fe7-fc35bc832d0a.mov

