### PR TITLE
fix app constantly refreshing when directly going to a url

### DIFF
--- a/products/statement-generator/src/App.tsx
+++ b/products/statement-generator/src/App.tsx
@@ -57,11 +57,11 @@ const App: React.FC = () => {
   };
 
   return (
-    <ThemeProvider theme={theme}>
-      <Router basename={process.env.PUBLIC_URL}>
-        <RoutingContextProvider>
+    <Router basename={process.env.PUBLIC_URL}>
+      <RoutingContextProvider>
+        <FormStateContextProvider>
           <AffirmationContextProvider>
-            <FormStateContextProvider>
+            <ThemeProvider theme={theme}>
               <nav
                 style={{
                   width: '100%',
@@ -101,12 +101,12 @@ const App: React.FC = () => {
 
                 <Route component={NotFound} />
               </Switch>
-            </FormStateContextProvider>
+              <Navbar />
+            </ThemeProvider>
           </AffirmationContextProvider>
-        </RoutingContextProvider>
-        <Navbar />
-      </Router>
-    </ThemeProvider>
+        </FormStateContextProvider>
+      </RoutingContextProvider>
+    </Router>
   );
 };
 

--- a/products/statement-generator/src/App.tsx
+++ b/products/statement-generator/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   useHistory,
-  BrowserRouter as Router,
+  HashRouter as Router,
   Route,
   Switch,
 } from 'react-router-dom';

--- a/products/statement-generator/src/contexts/RoutingContext.tsx
+++ b/products/statement-generator/src/contexts/RoutingContext.tsx
@@ -89,10 +89,10 @@ const PreRoutingContextProvider = ({
       // redirect back to the first page when accessing another random page
       // (in the future we would first check what data is currently cached before
       // deciding if we redirect or not)
-    } else if (pageEnum !== PAGES[STEP_ENUMS.NONE] && formSteps.length <= 1) {
+      /* } else if (pageEnum !== PAGES[STEP_ENUMS.NONE] && formSteps.length <= 1) {
       setCurrentStepIdx(0);
       setFormSteps([STEP_ENUMS.NONE]);
-      navigateToFormPage(PAGES[STEP_ENUMS.NONE]);
+      navigateToFormPage(PAGES[STEP_ENUMS.NONE]); */
     } else if (newPageData.isViewedStep && !newPageData.isCurrentStep) {
       handleBrowserPageNav(stepEnum);
 


### PR DESCRIPTION
resolves #369
(hopefully, hard to tell because it's only an issue when not local) 

Changed to use a `HashRouter` instead of `BrowserRouter`. Because 
When we go to somewhere like `expungeassist.org/involvement-job`, the browser will ask the server to give them that page. But because this is actually a [single-page app](https://en.wikipedia.org/wiki/Single-page_application) and we don't set up a server, there will be nothing to serve. Changing it to a HashRouter will tell the browser to ignore things past the `/#` and serve the App.tsx page. Then it will let `react-router-dom` route us to the correct page.