### PR TITLE
#604 - generate the heading (Date, To Whom it May Concern) into the state

### DIFF
--- a/products/statement-generator/src/contexts/FormStateProps.ts
+++ b/products/statement-generator/src/contexts/FormStateProps.ts
@@ -66,6 +66,7 @@ export const defaultStepState = {
     clearRecordHow: '',
   },
   statements: {
+    heading: '',
     introduction: '',
     job: '',
     service: '',
@@ -204,6 +205,7 @@ export const sampleStepState = {
       'If my record no longer says I have poison resistance, I can be hired for other jobs.',
   },
   statements: {
+    heading: 'Today,\n\nDearly beloved,',
     closing: 'Yours Truly,\nDan the Man',
   },
 };

--- a/products/statement-generator/src/helpers/previewHelper.ts
+++ b/products/statement-generator/src/helpers/previewHelper.ts
@@ -79,7 +79,7 @@ export function getPreviewStatement(
 }
 
 export function generateFinal(formState: IStepState): string {
-  return PREVIEW_KEYS.reduce((accumulator, previewKey) => {
+  const statementBody = PREVIEW_KEYS.reduce((accumulator, previewKey) => {
     const statement = getPreviewStatement(formState, previewKey as AppUrl);
 
     // blank statement
@@ -95,4 +95,6 @@ export function generateFinal(formState: IStepState): string {
     // concat statement
     return `${accumulator}\n\n${statement}`;
   }, '');
+
+  return `${formState.statements.heading}\n\n${statementBody}\n\n${formState.statements.closing}`;
 }

--- a/products/statement-generator/src/pages-form/FinalizePreview.tsx
+++ b/products/statement-generator/src/pages-form/FinalizePreview.tsx
@@ -44,12 +44,6 @@ function FinalizeStep() {
   const classes = useStyles();
   const { formState } = useContext(FormStateContext);
 
-  const displayDate = new Date().toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-
   return (
     <ContentContainer>
       <div className={classes.purpleTitle}>
@@ -58,8 +52,7 @@ function FinalizeStep() {
       </div>
 
       <div className={classes.preview}>
-        <span>{`${displayDate},\n\n`}</span>
-        <span>{`To whom it may concern,\n\n`}</span>
+        <p>{formState.statements.heading}</p>
 
         {PREVIEW_KEYS.map((previewKey) => {
           const statement = getPreviewStatement(

--- a/products/statement-generator/src/pages/PreviewPage.tsx
+++ b/products/statement-generator/src/pages/PreviewPage.tsx
@@ -27,13 +27,20 @@ function PreviewPage() {
     }
   }
 
-  // hacky implementation to generate the closing statement here
+  // hacky implementation to generate the heading & closing statement here
   //  because it does not have a unique page to be generated via a preview
   useEffect(() => {
     if (currentStep === AppUrl.IntroductionPreview) {
+      const displayDate = new Date().toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      });
+
       updateStepToForm({
         statements: {
           ...formState.statements,
+          heading: `${displayDate},\n\nTo whom it may concern,`,
           closing: `Sincerely,\n${formState.introduction.fullName}`,
         },
       });


### PR DESCRIPTION
Fixes #604 

This should make it so `generateFinal()` includes the heading and closing when downloaded.