### PR TITLE
697 recoveryflow rename

### DIFF
--- a/products/statement-generator/public/locales/en/translation.json
+++ b/products/statement-generator/public/locales/en/translation.json
@@ -94,7 +94,7 @@
     "involvement": "Involvement",
     "job": "Employment",
     "unemployment": "Unemployment",
-    "recovery": "Recovery",
+    "recovery": "Self-improvement",
     "education": "Education",
     "parenting": "Parenting",
     "community_service": "Community service",
@@ -140,9 +140,9 @@
     "serviceDescription_input_placeholder": ""
   },
   "recovery_form": {
-    "recoveryName_input_label": "What is the name of the recovery program you are involved with?",
-    "recoveryName_input_placeholder": "Name of organization",
-    "recoveryDescription_input_label": "Why is this recovery program important to you?\n(2-3 complete sentences)",
+    "recoveryName_input_label": "What have you been doing for your own self-improvement? (For example, seeking therapy, getting help for addiction, exercising, etc.)",
+    "recoveryName_input_placeholder": "Name of activity",
+    "recoveryDescription_input_label": "Why is this important to you?\n(2-3 complete sentences)",
     "recoveryDescription_input_placeholder": ""
   },
   "education_form": {

--- a/products/statement-generator/src/contexts/RoutingContext.tsx
+++ b/products/statement-generator/src/contexts/RoutingContext.tsx
@@ -47,6 +47,7 @@ const PreRoutingContextProvider = ({
   const goBackPage = () => {
     const prevHistoryIdx = Math.max(historyIdx - 1, 0);
     const prevUrl = appHistory[prevHistoryIdx];
+    setAppHistory((prevArr) => prevArr.slice(0, -1));
     setHistoryIdx(prevHistoryIdx);
 
     setCanShowAffirmation(false);

--- a/products/statement-generator/src/contexts/RoutingContext.tsx
+++ b/products/statement-generator/src/contexts/RoutingContext.tsx
@@ -47,7 +47,6 @@ const PreRoutingContextProvider = ({
   const goBackPage = () => {
     const prevHistoryIdx = Math.max(historyIdx - 1, 0);
     const prevUrl = appHistory[prevHistoryIdx];
-    setAppHistory((prevArr) => prevArr.slice(0, -1));
     setHistoryIdx(prevHistoryIdx);
 
     setCanShowAffirmation(false);


### PR DESCRIPTION
Made changes to translation file to update "Recovery" to "Self-improvement" in all relevant spaces.  Reflects changes across logic over the app, thus form header logic was handled as a result.  Changed questions on flow and updated it with the new questions in respect to the new changes.