### PR TITLE
742 add arrow to back buttons sweeping update

### DIFF
--- a/products/statement-generator/src/components-layout/Affirmation.tsx
+++ b/products/statement-generator/src/components-layout/Affirmation.tsx
@@ -65,7 +65,7 @@ const Affirmation = () => {
         className={`${utilityClasses.buttonContainer} ${utilityClasses.justifyRight}`}
       >
         <Button
-          hasArrow
+          hasForwardArrow
           onClick={() => updateAffirmationData({ isActive: false })}
           buttonText={t(affirmationData.buttonText)}
         />

--- a/products/statement-generator/src/components-layout/FlowNavigation.tsx
+++ b/products/statement-generator/src/components-layout/FlowNavigation.tsx
@@ -72,6 +72,7 @@ export default function FlowNavigation({
           disabled={isBackDisabled}
           buttonText={backButtonLabel || 'BACK'}
           theme={backBtnTheme}
+          hasBackArrow
         />
       )}
 
@@ -82,7 +83,7 @@ export default function FlowNavigation({
           disabled={isNextDisabled}
           buttonText={nextButtonLabel || 'NEXT'}
           theme="dark"
-          hasArrow
+          hasForwardArrow
         />
       )}
     </div>

--- a/products/statement-generator/src/components/Button.tsx
+++ b/products/statement-generator/src/components/Button.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Theme, makeStyles, createStyles } from '@material-ui/core';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import { AppUrl } from 'contexts/RoutingProps';
 import RoutingContext from 'contexts/RoutingContext';
 
@@ -126,7 +127,8 @@ const useStyles = makeStyles<Theme, StyleProps>(({ palette }) =>
 interface ComponentProps {
   className?: string;
   theme?: string;
-  hasArrow?: boolean;
+  hasBackArrow?: boolean;
+  hasForwardArrow?: boolean;
   disabled?: boolean;
   icon?: React.ReactNode;
   buttonText?: string;
@@ -136,13 +138,14 @@ interface ComponentProps {
 const ButtonComponent = ({
   className = '',
   theme,
-  hasArrow,
+  hasBackArrow,
+  hasForwardArrow,
   disabled = false,
   icon,
   buttonText,
   onClick,
 }: ComponentProps) => {
-  const styleProps = { theme, hasArrow };
+  const styleProps = { theme, hasBackArrow, hasForwardArrow };
   const classes = useStyles(styleProps);
   return (
     <Button
@@ -151,9 +154,10 @@ const ButtonComponent = ({
       className={`${classes.root} ${className}`}
       onClick={onClick}
     >
+      {hasBackArrow && <ArrowBackIcon style={{ height: '.8em' }} />}
       {icon}
       {buttonText}
-      {hasArrow && <ArrowForwardIcon style={{ height: '.8em' }} />}
+      {hasForwardArrow && <ArrowForwardIcon style={{ height: '.8em' }} />}
     </Button>
   );
 };

--- a/products/statement-generator/src/components/PopUp.tsx
+++ b/products/statement-generator/src/components/PopUp.tsx
@@ -67,7 +67,11 @@ const AlertDialog: React.FC<AlertDialogProps> = ({ title, info }) => {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => handleClose()} buttonText="OK" hasArrow />
+          <Button
+            onClick={() => handleClose()}
+            buttonText="OK"
+            hasForwardArrow
+          />
         </DialogActions>
       </Dialog>
     </div>


### PR DESCRIPTION
*closes [742](https://github.com/hackforla/expunge-assist/issues/742)

**Changes I made**
---

- [x] Add arrow to back button on these pages:
   - [x]  https://expungeassist.org/#/./before-you-begin
   - [x] https://expungeassist.org/#/./advice
   - [x] https://expungeassist.org/#/./form/intro
   - [x] https://expungeassist.org/#/./form/introduction/preview
   - [x] https://expungeassist.org/#/./form/involvement
   - [x] https://expungeassist.org/#/./form/job
   - [x] https://expungeassist.org/#/./form/job/preview
   - [x] https://expungeassist.org/#/./form/recovery
   - [x] https://expungeassist.org/#/./form/recovery/preview
   - [x] https://expungeassist.org/#/./form/school
   - [x] https://expungeassist.org/#/./form/school/preview
   - [x] https://expungeassist.org/#/./form/something-else
   - [x] https://expungeassist.org/#/./form/something-else/preview
   - [x] https://expungeassist.org/#/./form/parenting
   - [x] https://expungeassist.org/#/./form/parenting/preview
   - [x] https://expungeassist.org/#/./form/community-service
   - [x] https://expungeassist.org/#/./form/community-service/preview
   - [x] https://expungeassist.org/#/./form/unemployment
   - [x] https://expungeassist.org/#/./form/unemployment/preview
   - [x] https://expungeassist.org/#/./form/goals
   - [x] https://expungeassist.org/#/./form/goals/preview
   - [x] https://expungeassist.org/#/./form/why
   - [x] https://expungeassist.org/#/./form/why/preview
   - [x] https://expungeassist.org/#/./form/finalize
   - [x] https://expungeassist.org/#/./form/finalize/preview


**Notes**

- These buttons I could not find and am not sure if should be added:
  - [ ] https://expungeassist.org/#/./welcome 
