### PR TITLE
1002 changed to browser router

### DIFF
--- a/products/statement-generator/src/App.tsx
+++ b/products/statement-generator/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HashRouter as Router, Route, Switch } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { ThemeProvider } from '@material-ui/core/styles';
 
 import { RoutingContextProvider } from 'contexts/RoutingContext';
@@ -53,7 +53,7 @@ const App: React.FC = () => {
 
   return (
     <ThemeProvider theme={customMuiTheme}>
-      <Router basename={`${process.env.PUBLIC_URL}/`} hashType="slash">
+      <Router basename={`${process.env.PUBLIC_URL}/`}>
         <RoutingContextProvider>
           <AffirmationContextProvider>
             <FormStateContextProvider>


### PR DESCRIPTION
Fixes #1002 

- The "#" and "/./" were being added because the navigation was done by the hashRouter component. 
- I swapped it out for the browserRouter component: [https://reactrouter.com/en/main/router-components/browser-router](url)
- It's working great on my system and according to docs can be compatible with this repo, but there is a chance ghpages may give us a problem
- If it does, one possible solution includes setting the "homepage" property to the URL of the custom domain

I'm not aware of any way to test how github pages will treat it beforehand, but if there is please let me know!