### PR TITLE
1017 deleting script to fix url loop

### DIFF
--- a/products/statement-generator/public/index.html
+++ b/products/statement-generator/public/index.html
@@ -2,34 +2,6 @@
 <html lang="en">
   <head>
     <title>Expunge Assist</title>
-    <script type="text/javascript">
-      // Single Page Apps for GitHub Pages
-      // MIT License
-      // https://github.com/rafgraph/spa-github-pages
-      // This script checks to see if a redirect is present in the query string,
-      // converts it back into the correct url and adds it to the
-      // browser's history using window.history.replaceState(...),
-      // which won't cause the browser to attempt to load the new url.
-      // When the single page app is loaded further down in this file,
-      // the correct url will be waiting in the browser's history for
-      // the single page app to route accordingly.
-      (function (l) {
-        if (l.search[1] === '/') {
-          var decoded = l.search
-            .slice(1)
-            .split('&')
-            .map(function (s) {
-              return s.replace(/~and~/g, '&');
-            })
-            .join('?');
-          window.history.replaceState(
-            null,
-            null,
-            l.pathname.slice(0, -1) + decoded + l.hash
-          );
-        }
-      })(window.location);
-    </script>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
#1017 
- Bug fix attempt #1!
- This script I deleted worked with the original HashRouter and is responsible for adding the infinite "/~and~/" in the url
- Locally it works fine without the script, but I can't test its effects in production
- If this doesn't fix the bug, reverting to the previous router (including keeping the script this pull request is deleting) might be the best temporary option