### PR TITLE
1026 URL clean up

### DIFF
--- a/products/statement-generator/package.json
+++ b/products/statement-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "version": "0.8.0",
-  "homepage": "./",
+  "homepage": "https://expungeassist.org",
   "private": true,
   "engines": {
     "npm": ">=8.0.0",

--- a/products/statement-generator/src/App.tsx
+++ b/products/statement-generator/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HashRouter as Router, Route, Switch } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { ThemeProvider } from '@material-ui/core/styles';
 
 import { RoutingContextProvider } from 'contexts/RoutingContext';
@@ -53,7 +53,7 @@ const App: React.FC = () => {
 
   return (
     <ThemeProvider theme={customMuiTheme}>
-      <Router basename="/" hashType="slash">
+      <Router basename={`${process.env.PUBLIC_URL}/`}>
         <RoutingContextProvider>
           <AffirmationContextProvider>
             <FormStateContextProvider>

--- a/products/statement-generator/src/App.tsx
+++ b/products/statement-generator/src/App.tsx
@@ -53,7 +53,7 @@ const App: React.FC = () => {
 
   return (
     <ThemeProvider theme={customMuiTheme}>
-      <Router basename={`${process.env.PUBLIC_URL}/`} hashType="slash">
+      <Router basename="/" hashType="slash">
         <RoutingContextProvider>
           <AffirmationContextProvider>
             <FormStateContextProvider>


### PR DESCRIPTION
For issue #1026 

### Fix:

Update the `<Router basename>` prop in App.tsx from `<Router basename={`${process.env.PUBLIC_URL}/`}` to `<Router basename="/">`


### Explanation:

The `basename` prop is used to specify the base URL for all the routes in the app. In the code, we are dynamically setting the `basename` based on the value of the `PUBLIC_URL` environment variable.

The `PUBLIC_URL` environment variable is set by Create React App during the build process based on the package.json's `"homepage"` field. The `"homepage"` is set to "./" for our application.

When the `"homepage"` in package.json is set to "./", it means that the PUBLIC_URL environment variable will also be set to "./". This value represents the current directory as the base URL.

When you have a basename and PUBLIC_URL essentially both set to "./", relative URLs in the app may be interpreted as relative to the current directory. I believe this is what is leading to the unexpected URL behavior where extra /./ segments are added when navigating between routes.

By setting the `basename` prop in the Router to "/", we are explicitly specifying the base URL for all the routes in the app as the root URL (i.e., /). This means that the routes will start from the root of the domain.

With the `"homepage"` in package.json set to "./", it doesn't define a specific base URL. Instead, it allows the Router's basename to take precedence.

This approach fixes the URL bug and doesn't introduce any other bugs that I have been able to find.


<details>
<summary>Visuals before changes are applied</summary>

![1 - before - page load](https://github.com/hackforla/expunge-assist/assets/21321101/79ae7ffa-8500-4608-a620-2426c3b90f42)
![2 - before - link 1 clicked](https://github.com/hackforla/expunge-assist/assets/21321101/256e0c54-34f1-49a0-8b01-12e65956be92)
![3 - before - link 2 clicked](https://github.com/hackforla/expunge-assist/assets/21321101/dcf73b0b-c7c9-4553-8f8e-a383fa208af2)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![1 - after - page load](https://github.com/hackforla/expunge-assist/assets/21321101/47ce72c3-4f26-4953-8503-774d19786079)
![2 - after - link 1 clicked](https://github.com/hackforla/expunge-assist/assets/21321101/1ddcb5af-fc9a-4cfe-9690-2a2efd0ea96d)
![3 - after - link 2 clicked](https://github.com/hackforla/expunge-assist/assets/21321101/84d7412a-6458-4f1d-91f3-370c46d8ea65)

</details>


### Additional notes:

In the future if we want to switch to BrowserRouter, I believe the IIFE in the head of public/index.html is the culprit for the infinite loop of `/~and~/`:

`<script type="text/javascript">
      (function (l) {
        if (l.search[1] === '/') {
          var decoded = l.search
            .slice(1)
            .split('&')
            .map(function (s) {
              return s.replace(/~and~/g, '&');
            })
            .join('?');
          window.history.replaceState(
            null,
            null,
            l.pathname.slice(0, -1) + decoded + l.hash
          );
        }
      })(window.location);
    </script>`