### PR TITLE
945 Fix progress bar behavior

### DIFF
--- a/products/statement-generator/src/components/FormHeader.tsx
+++ b/products/statement-generator/src/components/FormHeader.tsx
@@ -119,6 +119,11 @@ const FormHeader = () => {
     formState: { involvement },
   } = useContext(FormStateContext);
 
+  const isFrozen = currentStep === AppUrl.Involvement;
+
+  const stepNum = convertStepToNum(currentStep, involvement);
+  let maxNum = 6;
+
   const {
     isJobChecked,
     isCommunityChecked,
@@ -128,8 +133,7 @@ const FormHeader = () => {
     isSomethingElseChecked,
     isUnemploymentChecked,
   } = involvement;
-  let maxNum = 6;
-  const stepNum = convertStepToNum(currentStep, involvement);
+
   if (isJobChecked) {
     maxNum += 1;
   }
@@ -152,11 +156,13 @@ const FormHeader = () => {
     maxNum += 1;
   }
 
-  if (currentStep === AppUrl.Involvement) {
-    maxNum = 6;
-  }
+  let percentageComplete;
 
-  const percentageComplete = (stepNum / maxNum) * 100;
+  if (isFrozen) {
+    percentageComplete = 20;
+  } else {
+    percentageComplete = (stepNum / maxNum) * 100;
+  }
 
   const formTitle = getSectionTitle(currentStep);
 


### PR DESCRIPTION
### Summary

- **Initial Behavior:** The progress bar updated dynamically based on user interactions on the Involvement page. It calculated the completion percentage by considering the number of checked/unchecked boxes, affecting the total steps the progress bar would display.
- **Underlying Issue:** The progress bar's dynamic behavior led to inconsistent movement, impacting the user experience. The formula used to determine the progress percentage was too sensitive to user interactions on the `Involvement` page, causing fluctuations in the progress bar's advancement. Depending on how many boxes were checked, the calculation of the current step against the theoretical amount of max steps would cause the bar to move forwards and backwards.

- **Fixed Behavior:** I refactored the code to ensure the progress bar remains static when the user is on the `Involvement` page (AppUrl.Involvement). The `Involvement` page is _always_ step 2. The `percentageComplete` variable that affects the `ProgressBar` is _always_ ~16% after step 1. By checking every box on the `Involvement` page on step 2, the lowest possible `percentageComplete` on reaching step 3 is ~23%. Implementing this change means the `ProgressBar` becomes locked at a consistent percentage (20%) while the user interacts with the checkboxes, offering a more predictable and stable visual representation of the progress. 

- **Testing & Validation:** Rigorous testing was conducted across various checkbox combinations to ensure the progress bar accurately reflects the user's progress, maintaining consistency and reliability throughout different form completion scenarios.