### PR TITLE
Remove scroll #1098

### DIFF
--- a/products/statement-generator/src/components-layout/Affirmation.tsx
+++ b/products/statement-generator/src/components-layout/Affirmation.tsx
@@ -49,7 +49,6 @@ const Affirmation = () => {
         paper: classes.affirmationContainer,
       }}
       fullWidth
-      disableScrollLock
       open={affirmationData.isActive}
       onClose={() => updateAffirmationData({ isActive: false })}
       aria-labelledby="alert-dialog-title"

--- a/products/statement-generator/src/components-layout/Affirmation.tsx
+++ b/products/statement-generator/src/components-layout/Affirmation.tsx
@@ -49,6 +49,7 @@ const Affirmation = () => {
         paper: classes.affirmationContainer,
       }}
       fullWidth
+      disableScrollLock
       open={affirmationData.isActive}
       onClose={() => updateAffirmationData({ isActive: false })}
       aria-labelledby="alert-dialog-title"


### PR DESCRIPTION
Issue: #1098 

I have removed the `disabledScrollLock` attribute from Affrimation.tsx Dialog Component to remove the scroll behind the Affirmation modal.