### PR TITLE
#1151 Letter Generator Progress Bar Bug

### DIFF
--- a/products/statement-generator/src/components/FormHeader.tsx
+++ b/products/statement-generator/src/components/FormHeader.tsx
@@ -43,9 +43,6 @@ const useStyles = makeStyles<Theme>(
         marginTop: '10px',
         marginBottom: '8px',
       },
-      hidden: {
-        display: 'none',
-      },
     })
 );
 
@@ -135,8 +132,6 @@ const FormHeader = () => {
   const isFormRoute =
     location.pathname.startsWith('/form/') || location.pathname === '/form';
 
-  const headerClass = isFormRoute ? '' : classes.hidden;
-
   const isFrozen = currentStep === AppUrl.Involvement;
 
   const stepNum = convertStepToNum(currentStep, involvement);
@@ -184,12 +179,12 @@ const FormHeader = () => {
 
   const formTitle = getSectionTitle(currentStep);
 
-  if (stepNum === 0) {
+  if (!isFormRoute || stepNum === 0) {
     return null;
   }
 
   return (
-    <div className={`${classes.outerWrapper} ${headerClass}`}>
+    <div className={classes.outerWrapper}>
       <div className={classes.formHeader}>
         <h3 className={classes.formTitle}>{formTitle}</h3>
 

--- a/products/statement-generator/src/components/FormHeader.tsx
+++ b/products/statement-generator/src/components/FormHeader.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Theme, makeStyles, createStyles } from '@material-ui/core';
 
 import RoutingContext from 'contexts/RoutingContext';
@@ -41,6 +42,9 @@ const useStyles = makeStyles<Theme>(
       formTitle: {
         marginTop: '10px',
         marginBottom: '8px',
+      },
+      hidden: {
+        display: 'none',
       },
     })
 );
@@ -127,6 +131,12 @@ const FormHeader = () => {
     formState: { involvement },
   } = useContext(FormStateContext);
 
+  const location = useLocation();
+  const isFormRoute =
+    location.pathname.startsWith('/form/') || location.pathname === '/form';
+
+  const headerClass = isFormRoute ? '' : classes.hidden;
+
   const isFrozen = currentStep === AppUrl.Involvement;
 
   const stepNum = convertStepToNum(currentStep, involvement);
@@ -179,7 +189,7 @@ const FormHeader = () => {
   }
 
   return (
-    <div className={classes.outerWrapper}>
+    <div className={`${classes.outerWrapper} ${headerClass}`}>
       <div className={classes.formHeader}>
         <h3 className={classes.formTitle}>{formTitle}</h3>
 


### PR DESCRIPTION
### **Fixes** #1151

**Issue:**

The `FormHeader` (including `ProgressBar`) would continue to display if a user clicked on a footer link from anywhere within the form.

**Solution:**

Implement useLocation hook to keep track of the current URL, then conditionally render the FormHeader with CSS when the user is on a form page `https://expungeassist.org/form/`, `https://expungeassist.org/form/intro`, etc. -- otherwise it is hidden.