### PR TITLE
#1074 Keyboard users lose focus

### DIFF
--- a/products/statement-generator/src/components/Checkbox.tsx
+++ b/products/statement-generator/src/components/Checkbox.tsx
@@ -44,29 +44,29 @@ interface IInnerCheckboxProps extends CheckboxProps {
   useTeal?: boolean;
 }
 
-const InnerCheckbox = ({
-  checked,
-  onChange,
-  id,
-  useTeal,
-}: IInnerCheckboxProps) => {
-  const classes = useStyles({ theme: useTeal ? 'teal' : 'black' });
-  return (
-    <Checkbox classes={classes} checked={checked} onChange={onChange} id={id} />
-  );
-};
+const InnerCheckbox = React.forwardRef<HTMLInputElement, IInnerCheckboxProps>(
+  ({ checked, onChange, id, useTeal }, ref) => {
+    const classes = useStyles({ theme: useTeal ? 'teal' : 'black' });
+    return (
+      <Checkbox
+        classes={classes}
+        checked={checked}
+        onChange={onChange}
+        id={id}
+        inputRef={ref}
+      />
+    );
+  }
+);
 
 interface IWrapperCheckboxProps extends IInnerCheckboxProps {
   label: string;
 }
 
-const CheckboxLabels: React.FC<IWrapperCheckboxProps> = ({
-  label,
-  checked,
-  onChange,
-  id,
-  useTeal = false,
-}) => {
+const CheckboxLabels = React.forwardRef<
+  HTMLInputElement,
+  IWrapperCheckboxProps
+>(({ label, checked, onChange, id, useTeal = false }, ref) => {
   return (
     <FormControlLabel
       control={
@@ -75,11 +75,12 @@ const CheckboxLabels: React.FC<IWrapperCheckboxProps> = ({
           id={id}
           checked={checked}
           onChange={onChange}
+          ref={ref}
         />
       }
       label={label}
     />
   );
-};
+});
 
 export default CheckboxLabels;

--- a/products/statement-generator/src/components/TextPreview.tsx
+++ b/products/statement-generator/src/components/TextPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 
 import { makeStyles, createStyles } from '@material-ui/core';
 import CreateIcon from '@material-ui/icons/Create';
@@ -43,47 +43,48 @@ interface ComponentProps {
   style?: object;
 }
 
-const TextPreview = ({
-  onSaveClick,
-  content,
-  nameOfStep,
-  className = '',
-  style,
-}: ComponentProps) => {
-  const classes = useStyles();
-  const utilityClasses = useUtilityStyles();
-  const [isEditing, setIsEditing] = useState<boolean>(false);
+const TextPreview = forwardRef<HTMLDivElement, ComponentProps>(
+  ({ onSaveClick, content, nameOfStep, className = '', style }, ref) => {
+    const classes = useStyles();
+    const utilityClasses = useUtilityStyles();
+    const [isEditing, setIsEditing] = useState<boolean>(false);
 
-  const handleClick = () => {
-    setIsEditing(true);
-  };
+    const handleClick = () => {
+      setIsEditing(true);
+    };
 
-  return (
-    <div className={`${classes.root} ${className}`} style={style}>
-      <div className={classes.previewHeader}>
-        <h3>{nameOfStep}</h3>
+    return (
+      <div
+        ref={ref}
+        className={`${classes.root} ${className}`}
+        style={style}
+        tabIndex={-1} // Make this div focusable
+      >
+        <div className={classes.previewHeader}>
+          <h3>{nameOfStep}</h3>
 
-        <div className={classes.actionHeader}>
-          {!isEditing && (
-            <CreateIcon
-              className={utilityClasses.iconButton}
-              onClick={handleClick}
-            />
-          )}
+          <div className={classes.actionHeader}>
+            {!isEditing && (
+              <CreateIcon
+                className={utilityClasses.iconButton}
+                onClick={handleClick}
+              />
+            )}
+          </div>
         </div>
-      </div>
 
-      {isEditing ? (
-        <EditContent
-          content={content}
-          setIsEditing={setIsEditing}
-          onSaveClick={onSaveClick}
-        />
-      ) : (
-        <p>{content}</p>
-      )}
-    </div>
-  );
-};
+        {isEditing ? (
+          <EditContent
+            content={content}
+            setIsEditing={setIsEditing}
+            onSaveClick={onSaveClick}
+          />
+        ) : (
+          <p>{content}</p>
+        )}
+      </div>
+    );
+  }
+);
 
 export default TextPreview;

--- a/products/statement-generator/src/components/TextPreview.tsx
+++ b/products/statement-generator/src/components/TextPreview.tsx
@@ -66,8 +66,18 @@ const TextPreview = forwardRef<HTMLDivElement, ComponentProps>(
           <div className={classes.actionHeader}>
             {!isEditing && (
               <CreateIcon
-                className={utilityClasses.iconButton}
+                className={`${utilityClasses.iconButton} create-icon-focusable`}
                 onClick={handleClick}
+                tabIndex={0}
+                role="button"
+                aria-label="Edit content"
+                onKeyDown={(e) => {
+                  // Check if the key pressed is Enter or Spacebar
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    handleClick();
+                    e.preventDefault(); // Prevent the default action to avoid scrolling on Spacebar press
+                  }
+                }}
               />
             )}
           </div>

--- a/products/statement-generator/src/components/TextPreview.tsx
+++ b/products/statement-generator/src/components/TextPreview.tsx
@@ -58,7 +58,7 @@ const TextPreview = forwardRef<HTMLDivElement, ComponentProps>(
         ref={ref}
         className={`${classes.root} ${className}`}
         style={style}
-        tabIndex={-1} // Make this div focusable
+        tabIndex={-1}
       >
         <div className={classes.previewHeader}>
           <h3>{nameOfStep}</h3>
@@ -72,10 +72,9 @@ const TextPreview = forwardRef<HTMLDivElement, ComponentProps>(
                 role="button"
                 aria-label="Edit content"
                 onKeyDown={(e) => {
-                  // Check if the key pressed is Enter or Spacebar
                   if (e.key === 'Enter' || e.key === ' ') {
                     handleClick();
-                    e.preventDefault(); // Prevent the default action to avoid scrolling on Spacebar press
+                    e.preventDefault();
                   }
                 }}
               />

--- a/products/statement-generator/src/components/Textarea.tsx
+++ b/products/statement-generator/src/components/Textarea.tsx
@@ -78,45 +78,51 @@ interface TextFieldProps {
   rows?: number;
 }
 
-const MultilineTextFields: React.FC<TextFieldProps> = ({
-  handleChange,
-  id,
-  label,
-  placeholder,
-  defaultValue,
-  disabled = false,
-  value,
-  rows,
-}) => {
-  const utilityClasses = useUtilityStyles();
-  const classes = useStyles();
+const MultilineTextFields = React.forwardRef<HTMLDivElement, TextFieldProps>(
+  (
+    {
+      handleChange,
+      id,
+      label,
+      placeholder,
+      defaultValue,
+      disabled = false,
+      value,
+      rows,
+    },
+    ref
+  ) => {
+    const utilityClasses = useUtilityStyles();
+    const classes = useStyles();
 
-  return (
-    <div className={utilityClasses.formInput}>
-      {label && (
-        <InputLabel htmlFor={id} disabled={disabled}>
-          {label}
-        </InputLabel>
-      )}
+    return (
+      <div className={utilityClasses.formInput}>
+        {label && (
+          <InputLabel htmlFor={id} disabled={disabled}>
+            {label}
+          </InputLabel>
+        )}
 
-      <TextField
-        id={id}
-        className={classes.textfieldComponent}
-        onChange={handleChange}
-        placeholder={placeholder}
-        defaultValue={defaultValue}
-        disabled={disabled}
-        value={value}
-        rows={rows}
-        multiline
-        fullWidth
-        variant="outlined"
-        InputProps={{
-          notched: false,
-        }}
-      />
-    </div>
-  );
-};
+        <TextField
+          id={id}
+          className={classes.textfieldComponent}
+          onChange={handleChange}
+          placeholder={placeholder}
+          defaultValue={defaultValue}
+          disabled={disabled}
+          value={value}
+          rows={rows}
+          multiline
+          fullWidth
+          variant="outlined"
+          InputProps={{
+            notched: false,
+          }}
+          inputRef={ref}
+        />
+      </div>
+    );
+  }
+);
 
 export default MultilineTextFields;

--- a/products/statement-generator/src/pages-form/FinalizeForm.tsx
+++ b/products/statement-generator/src/pages-form/FinalizeForm.tsx
@@ -58,7 +58,6 @@ function FinalizeForm() {
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="0"])'
       );
 
-      // Use type assertion to tell TypeScript this is an HTMLElement
       if (firstFocusableElement instanceof HTMLElement) {
         firstFocusableElement.focus();
       }

--- a/products/statement-generator/src/pages-form/FinalizeForm.tsx
+++ b/products/statement-generator/src/pages-form/FinalizeForm.tsx
@@ -50,11 +50,18 @@ function FinalizeForm() {
 
   const { affirmationData } = useContext(AffirmationContext);
 
-  const finalRef = useRef<HTMLDivElement>(null);
+  const previewsContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!affirmationData.isActive) {
-      finalRef.current?.focus();
+      const firstFocusableElement = previewsContainerRef.current?.querySelector(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+
+      // Use type assertion to tell TypeScript this is an HTMLElement
+      if (firstFocusableElement instanceof HTMLElement) {
+        firstFocusableElement.focus();
+      }
     }
   }, [affirmationData.isActive]);
 
@@ -100,7 +107,7 @@ function FinalizeForm() {
         Editing final letter
       </div>
 
-      {previewComponents}
+      <div ref={previewsContainerRef}>{previewComponents}</div>
 
       <TextPreview
         className={classes.previewItem}

--- a/products/statement-generator/src/pages-form/FinalizeForm.tsx
+++ b/products/statement-generator/src/pages-form/FinalizeForm.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { makeStyles, createStyles } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
@@ -19,6 +19,8 @@ import {
   PREVIEW_MAP,
   PREVIEW_KEYS,
 } from 'helpers/previewHelper';
+
+import { AffirmationContext } from 'contexts/AffirmationContext';
 
 const useStyles = makeStyles(({ palette, spacing }) =>
   createStyles({
@@ -45,6 +47,16 @@ function FinalizeForm() {
   const { t } = useTranslation();
   const classes = useStyles();
   const { formState, updateStepToForm } = useContext(FormStateContext);
+
+  const { affirmationData } = useContext(AffirmationContext);
+
+  const finalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!affirmationData.isActive) {
+      finalRef.current?.focus();
+    }
+  }, [affirmationData.isActive]);
 
   function updatePreviewItem(newStatement: string, stateKey: string) {
     updateStepToForm({

--- a/products/statement-generator/src/pages-form/FinalizeForm.tsx
+++ b/products/statement-generator/src/pages-form/FinalizeForm.tsx
@@ -55,7 +55,7 @@ function FinalizeForm() {
   useEffect(() => {
     if (!affirmationData.isActive) {
       const firstFocusableElement = previewsContainerRef.current?.querySelector(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="0"])'
       );
 
       // Use type assertion to tell TypeScript this is an HTMLElement

--- a/products/statement-generator/src/pages-form/GoalsStep.tsx
+++ b/products/statement-generator/src/pages-form/GoalsStep.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import FormStateContext from 'contexts/FormStateContext';
@@ -8,10 +8,22 @@ import FlowNavigation from 'components-layout/FlowNavigation';
 import ContentContainer from 'components-layout/ContentContainer';
 import Textarea from 'components/Textarea';
 
+import { AffirmationContext } from 'contexts/AffirmationContext';
+
 function GoalsStep() {
   const { t } = useTranslation();
   const { formState, updateStepToForm } = useContext(FormStateContext);
   const { goals, goalsHow } = formState.goalsState;
+
+  const { affirmationData } = useContext(AffirmationContext);
+
+  const goalsRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!affirmationData.isActive) {
+      goalsRef.current?.focus();
+    }
+  }, [affirmationData.isActive]);
 
   const goalsValid = goals !== '';
   const goalsHowValid = goalsHow !== '';
@@ -28,6 +40,7 @@ function GoalsStep() {
   return (
     <ContentContainer>
       <Textarea
+        ref={goalsRef}
         id="goals"
         label={t('goals_form.goals_input_label')}
         placeholder={t('goals_form.goals_input_placeholder')}

--- a/products/statement-generator/src/pages-form/InvolvementInitialFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementInitialFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { Theme, createStyles, makeStyles } from '@material-ui/core/styles';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControl from '@material-ui/core/FormControl';
@@ -6,6 +6,8 @@ import FormGroup from '@material-ui/core/FormGroup';
 import { useTranslation } from 'react-i18next';
 
 import FormStateContext from 'contexts/FormStateContext';
+
+import { AffirmationContext } from 'contexts/AffirmationContext';
 
 import Checkbox from 'components/Checkbox';
 
@@ -33,6 +35,14 @@ const useStyles = makeStyles<Theme>(({ palette, spacing }) =>
 function InvolvementInitialFlow() {
   const { t } = useTranslation();
   const classes = useStyles();
+  const { affirmationData } = useContext(AffirmationContext);
+  const firstCheckboxRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!affirmationData.isActive) {
+      firstCheckboxRef.current?.focus();
+    }
+  }, [affirmationData.isActive]);
 
   const { formState, updateStepToForm } = useContext(FormStateContext);
   const {
@@ -73,6 +83,7 @@ function InvolvementInitialFlow() {
           </FormLabel>
           <FormGroup id="involvement-checkboxes">
             <Checkbox
+              ref={firstCheckboxRef}
               useTeal
               id="isJobChecked"
               checked={isJobChecked}

--- a/products/statement-generator/src/pages-form/WhyStep.tsx
+++ b/products/statement-generator/src/pages-form/WhyStep.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import FormStateContext from 'contexts/FormStateContext';
@@ -9,10 +9,22 @@ import ContentContainer from 'components-layout/ContentContainer';
 import FlowNavigation from 'components-layout/FlowNavigation';
 import FormContainer from 'components-layout/FormContainer';
 
+import { AffirmationContext } from 'contexts/AffirmationContext';
+
 function WhyStep() {
   const { t } = useTranslation();
   const { formState, updateStepToForm } = useContext(FormStateContext);
   const { clearRecordWhy, clearRecordHow } = formState.whyState;
+
+  const { affirmationData } = useContext(AffirmationContext);
+
+  const whyRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!affirmationData.isActive) {
+      whyRef.current?.focus();
+    }
+  }, [affirmationData.isActive]);
 
   const clearRecordWhyValid = clearRecordWhy !== '';
   const clearRecordHowValid = clearRecordHow !== '';
@@ -30,6 +42,7 @@ function WhyStep() {
     <ContentContainer>
       <FormContainer>
         <Textarea
+          ref={whyRef}
           id="clearRecordWhy"
           label={t('why_form.clearRecordWhy_input_label')}
           placeholder={t('why_form.clearRecordWhy_input_placeholder')}


### PR DESCRIPTION
### Fixes: [#1074](https://github.com/hackforla/expunge-assist/issues/1074)

## Issue: 
While navigating the site by keyboard, the focus resets when a user closes the affirmation/popup. A keyboard user could be deeply inconvenienced by this and it could stop them from finishing the letter generator.

## Solution: 
Implemented useEffect statements and useRef statements regarding the pages the affirmation component pops up on. Also made 'edit' icon svg openable by keyboard. 

