### PR TITLE
Update alt label for Footer HfLA link

### DIFF
--- a/products/statement-generator/src/components-layout/AppFooter.tsx
+++ b/products/statement-generator/src/components-layout/AppFooter.tsx
@@ -126,7 +126,7 @@ function HackForLACopyright() {
         <img
           className={classes.hackforlaIcon}
           src={hackForLALogo}
-          alt="Hack for LA Logo"
+          alt="Link to Hack for LA site"
         />
       </a>
       <span className={classes.reg}>© 2022 Hack for LA</span>


### PR DESCRIPTION
Fixes #1232 

### Changes made
- Update HfLA logo `alt` label to `Link to Hack for LA site` 

### Reason for changes
- Per issue, screen readers use `aria-labels` and `alt` attributes to identify the selected element to the user. In our footer, the link to the HfLA site `alt` identifies the image as the HfLA logo, but not the _function_ of the link. Because this image is being used as a button, the `alt` needs to describe the function.