### PR TITLE
1172 fix faq alignment

### DIFF
--- a/products/statement-generator/src/components-layout/AppFooter.tsx
+++ b/products/statement-generator/src/components-layout/AppFooter.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles(({ breakpoints, palette, spacing }) =>
       color: palette.common.black,
       display: 'flex',
       alignItems: 'center',
-      padding: spacing(2, 3),
+      padding: spacing(1, 2),
 
       [breakpoints.down(breakpoints.values.md)]: {
         flexDirection: 'column',
@@ -38,12 +38,6 @@ const useStyles = makeStyles(({ breakpoints, palette, spacing }) =>
     leftContainer: {
       display: 'flex',
       flexDirection: 'column',
-      padding: spacing(1),
-      marginLeft: '-16px',
-
-      [breakpoints.down(breakpoints.values.md)]: {
-        marginLeft: '-8px',
-      },
     },
     rightContainer: {
       display: 'flex',
@@ -53,7 +47,8 @@ const useStyles = makeStyles(({ breakpoints, palette, spacing }) =>
 
       [breakpoints.down(breakpoints.values.md)]: {
         flexDirection: 'column',
-        marginLeft: '-8px',
+        justifyContent: 'start',
+        marginTop: spacing(1),
       },
     },
     linkBtn: {
@@ -75,12 +70,21 @@ const useStyles = makeStyles(({ breakpoints, palette, spacing }) =>
         marginLeft: 4,
       },
 
+      [breakpoints.down(breakpoints.values.md)]: {
+        marginTop: 16,
+        padding: spacing(1, 0),
+      },
+
       [breakpoints.down(breakpoints.values.sm)]: {
         marginTop: 16,
       },
     },
     copyrightContainer: {
       display: 'flex',
+
+      [breakpoints.down(breakpoints.values.md)]: {
+        marginTop: 16,
+      },
 
       [breakpoints.down(breakpoints.values.sm)]: {
         marginTop: 16,
@@ -89,9 +93,17 @@ const useStyles = makeStyles(({ breakpoints, palette, spacing }) =>
     hackforlaIcon: {
       height: 25,
       margin: 'auto 10px',
+
+      [breakpoints.down(breakpoints.values.md)]: {
+        margin: 'auto 0',
+      },
     },
     reg: {
       margin: 'auto 0',
+
+      [breakpoints.down(breakpoints.values.md)]: {
+        marginLeft: spacing(1),
+      },
     },
     line: {
       margin: 'auto 0',

--- a/products/statement-generator/src/components-layout/AppFooter.tsx
+++ b/products/statement-generator/src/components-layout/AppFooter.tsx
@@ -39,6 +39,11 @@ const useStyles = makeStyles(({ breakpoints, palette, spacing }) =>
       display: 'flex',
       flexDirection: 'column',
       padding: spacing(1),
+      marginLeft: '-16px',
+
+      [breakpoints.down(breakpoints.values.md)]: {
+        marginLeft: '-8px',
+      },
     },
     rightContainer: {
       display: 'flex',
@@ -48,6 +53,7 @@ const useStyles = makeStyles(({ breakpoints, palette, spacing }) =>
 
       [breakpoints.down(breakpoints.values.md)]: {
         flexDirection: 'column',
+        marginLeft: '-8px',
       },
     },
     linkBtn: {

--- a/products/statement-generator/src/components-layout/AppFooter.tsx
+++ b/products/statement-generator/src/components-layout/AppFooter.tsx
@@ -47,7 +47,6 @@ const useStyles = makeStyles(({ breakpoints, palette, spacing }) =>
 
       [breakpoints.down(breakpoints.values.md)]: {
         flexDirection: 'column',
-        justifyContent: 'start',
         marginTop: spacing(1),
       },
     },
@@ -67,27 +66,27 @@ const useStyles = makeStyles(({ breakpoints, palette, spacing }) =>
       },
 
       '&$linkBtn + $linkBtn': {
-        marginLeft: 4,
+        marginLeft: spacing(0.5),
       },
 
       [breakpoints.down(breakpoints.values.md)]: {
-        marginTop: 16,
+        marginTop: spacing(2),
         padding: spacing(1, 0),
       },
 
       [breakpoints.down(breakpoints.values.sm)]: {
-        marginTop: 16,
+        marginTop: spacing(2),
       },
     },
     copyrightContainer: {
       display: 'flex',
 
       [breakpoints.down(breakpoints.values.md)]: {
-        marginTop: 16,
+        marginTop: spacing(2),
       },
 
       [breakpoints.down(breakpoints.values.sm)]: {
-        marginTop: 16,
+        marginTop: spacing(2),
       },
     },
     hackforlaIcon: {

--- a/products/statement-generator/src/components/Logo.tsx
+++ b/products/statement-generator/src/components/Logo.tsx
@@ -12,8 +12,7 @@ const useStyles = makeStyles<Theme, IUseUtilityStyle>(
         display: 'flex',
         fontSize: 20,
         maxHeight: ({ footer }: IUseUtilityStyle) => (footer ? '25px' : 'null'),
-        marginBottom: ({ footer }: IUseUtilityStyle) =>
-          footer ? '10px' : 'null',
+        marginBottom: ({ footer }: IUseUtilityStyle) => (footer ? 0 : 'null'),
 
         [breakpoints.down(breakpoints.values.sm)]: {
           // display: 'none',

--- a/products/statement-generator/src/pages/FAQ.tsx
+++ b/products/statement-generator/src/pages/FAQ.tsx
@@ -62,6 +62,7 @@ const useStyles = makeStyles(({ palette, breakpoints }) =>
       fontSize: '24px',
       lineHeight: '36px',
       fontWeight: 400,
+      textAlign: 'center',
     },
     ImgContainer: {
       width: '100%',
@@ -75,7 +76,7 @@ const useStyles = makeStyles(({ palette, breakpoints }) =>
       minWidth: '182px',
     },
     FAQContainer: {
-      maxWidth: '996px',
+      maxWidth: '980px',
       width: '100%',
       paddingTop: 0,
 

--- a/products/statement-generator/src/pages/FAQ.tsx
+++ b/products/statement-generator/src/pages/FAQ.tsx
@@ -38,12 +38,14 @@ const useStyles = makeStyles(({ palette, breakpoints }) =>
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'center',
-      alignItems: 'center',
+      alignItems: 'flex-start',
       backgroundColor: palette.primary.lighter,
-      marginRight: '113.5px',
+      flex: '1 1 60%',
+      marginRight: '36px',
 
       [breakpoints.down('md')]: {
         marginRight: 0,
+        alignItems: 'center',
       },
 
       [breakpoints.down('sm')]: {
@@ -64,6 +66,8 @@ const useStyles = makeStyles(({ palette, breakpoints }) =>
     ImgContainer: {
       width: '100%',
       textAlign: 'center',
+      flex: '1 1 40%',
+      marginRight: '16px',
     },
     Img: {
       width: 'auto',

--- a/products/statement-generator/src/pages/FAQ.tsx
+++ b/products/statement-generator/src/pages/FAQ.tsx
@@ -19,10 +19,10 @@ const useStyles = makeStyles(({ palette, breakpoints }) =>
       },
     },
     HeaderContent: {
-      maxWidth: '996px',
+      maxWidth: '945px',
       minWidth: '342px',
-      width: '69.2%',
-      margin: '45px 222px 54.64px',
+      width: '100%',
+      margin: '45px auto 54.64px',
       display: 'flex',
       justifyContent: 'space-between',
       alignItems: 'center',

--- a/products/statement-generator/src/pages/FAQ.tsx
+++ b/products/statement-generator/src/pages/FAQ.tsx
@@ -62,7 +62,10 @@ const useStyles = makeStyles(({ palette, breakpoints }) =>
       fontSize: '24px',
       lineHeight: '36px',
       fontWeight: 400,
-      textAlign: 'center',
+
+      [breakpoints.down(breakpoints.values.md)]: {
+        textAlign: 'center',
+      },
     },
     ImgContainer: {
       width: '100%',

--- a/products/statement-generator/src/pages/FAQ.tsx
+++ b/products/statement-generator/src/pages/FAQ.tsx
@@ -63,7 +63,7 @@ const useStyles = makeStyles(({ palette, breakpoints }) =>
       lineHeight: '36px',
       fontWeight: 400,
 
-      [breakpoints.down(breakpoints.values.md)]: {
+      [breakpoints.down(breakpoints.values.lg)]: {
         textAlign: 'center',
       },
     },

--- a/products/statement-generator/src/pages/FAQ.tsx
+++ b/products/statement-generator/src/pages/FAQ.tsx
@@ -72,7 +72,7 @@ const useStyles = makeStyles(({ palette, breakpoints }) =>
     },
     FAQContainer: {
       maxWidth: '996px',
-      width: '69.2%',
+      width: '100%',
       paddingTop: 0,
 
       [breakpoints.down('xs')]: {


### PR DESCRIPTION
Fixes #1172 

### Changes made

- Adjusted `AppFooter` to exactly match and align with `AppHeader` - otherwise none of the content would be aligned with both
- Adjusted `FAQHeader` content width to stay aligned with the `AppHeader` and `AppFooter`
- Adjusted `FAQHeader` text and image to have correct line numbers and spacing
- Adjusted `FAQContainer` content width to stay aligned with the `AppHeader` and `AppFooter`


### Reason for changes

- Implementation of the FAQ page did not match design team's wireframes. It has a more polished/professional look and feel now