### PR TITLE
1230 Make Header/Footer Logo Accessible

### DIFF
--- a/products/statement-generator/src/components/Logo.tsx
+++ b/products/statement-generator/src/components/Logo.tsx
@@ -75,7 +75,7 @@ export default function Logo({ theme, footer }: ILogoComponent) {
 
   return (
     <div className={classes.logoContainer}>
-      <Link to="/">
+      <Link to="/" aria-label="Expunge Assist home">
         <img src={logoIcon} alt="" />
       </Link>
 

--- a/products/statement-generator/src/components/Logo.tsx
+++ b/products/statement-generator/src/components/Logo.tsx
@@ -61,7 +61,7 @@ function TextLogo({ theme, footer }: ILogoComponent) {
   }
 
   return (
-    <Link to="/" className={classes.logoLink}>
+    <Link to="/" className={classes.logoLink} aria-label="Expunge Assist home">
       <span>Expunge</span>
       <span>Assist</span>
     </Link>


### PR DESCRIPTION
Fixes #1230  

### Changes made
- Added `aria-label` to link els (image and text) describing each link as 'Expunge Assist home'
- Screen reader now says "Visit link: Expunge Assist home" upon navigating to either image or text logo

### Reason for changes
- Screen readers use `aria-labels` and `alt` attributes to identify the selected element to the user. Because the Header and Footer Logos link to the Landing page dynamically and the image doesn't have alt text, Screen Readers don't know what to call these links.