### PR TITLE
1255 Update Actions and Deployment Script from Node 16.x to Node 20.x

### DIFF
--- a/.github/workflows/issue-update-reminder.yml
+++ b/.github/workflows/issue-update-reminder.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Check issue activity
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -12,14 +12,14 @@ jobs:
     permissions: write-all
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -30,7 +30,7 @@ jobs:
           npm run build
 
       - name: Publish generated content to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        uses: JamesIves/github-pages-deploy-action@v4.3.0
         with:
           folder: products/statement-generator/build
           branch: gh-pages

--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -30,7 +30,7 @@ jobs:
           npm run build
 
       - name: Publish generated content to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.3.0
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           folder: products/statement-generator/build
           branch: gh-pages

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -5,11 +5,15 @@ on: [pull_request]
 jobs:
   prettier:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x]
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -10,10 +10,10 @@ jobs:
         node-version: [20.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
Fixes #1255 

### Changes made
- Updated node-version from 16.x to 20.x
- Updated to latest versions of marketplace actions that account for Node 20 change
   - [actions/github-script@v7](https://github.com/actions/github-script/releases/tag/v7.0.0)
   - [actions/setup-node@v4](https://github.com/actions/setup-node/releases/tag/v4.0.0)
   - [actions/checkout@v4](https://github.com/actions/checkout/releases/tag/v4.0.0)
   - [JamesIves/github-pages-deploy-action@v4.5.0](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.5.0)
- Tested actions still worked using Act (resolved the network error by uninstalling/reinstalling Docker 🤷🏻‍♀️)
   - note that deployment step of master-deploy.yml fails

### Reason for changes
- Github has deprecated Node 16 in favor of Node 20 for use in Github Actions. To guarantee continued coverage, we need to update our actions to use Node 20.