### PR TITLE
1188 Add new Issue template for UI/UX Designer onboarding

### DIFF
--- a/.github/ISSUE_TEMPLATE/design-self-onboard.md
+++ b/.github/ISSUE_TEMPLATE/design-self-onboard.md
@@ -1,0 +1,145 @@
+---
+name: "Designer Pre-work"
+about: "An issue to help new designers get acquainted with our processes."
+title: "Self-Onboarding Designer: [NAME]"
+labels: "issue level I, priority: medium, role: missing, size: 1pt, feature: onboard / offboard"
+assignees: ""
+---
+
+## Overview
+
+To help you jump into the team and make Expunge Assist even better, this onboarding issue shares tips for using team resources. As a new UX/UI Designer at Expunge Assist, fill in the fields below as you tackle each onboarding task. Below is the table of content and areas of focus:
+
+| Focus Area              | Description                                                                                              |
+| ----------------------- | -------------------------------------------------------------------------------------------------------- |
+| Set-up                  | Take actionable steps to make sure you have everything set-up to begin contributing to the project.      |
+| Project Familiarization | Review background documentation to learn about EA and where the project is going.                        |
+| GitHub 101              | Using GitHub tends to be a learning curve for UX Designers. Learn about GitHub and how our team uses it. |
+| Your first issue        | Learn how to take your first Github issue and team best practices.                                       |
+| Team Resources          | A list of team resources that would be helpful to bookmark                                               |
+
+### Tip: Take your time :sparkles:
+
+Navigating through a lot of information can be overwhelming at first, but it's perfectly natural. Don't hesitate to ask questions whenever you need clarification. Embrace the journey of learning as you progress. Take your time with your onboarding tasks; there's no rush to be at full speed right away!
+
+### Questions?
+
+If you have questions, don't hesitate to mention @jyehllow or @anitadesigns (Design Co-leads), @vanessaavviles (Product Design Manager) You can also reach out to team members in the [`#expunge-assist-design-and-content` Slack channel](https://hackforla.slack.com/archives/C02T3EB0N77).
+
+## Set-up
+
+### Action Items
+
+- [ ] Set up this GitHub Issue
+
+  - [ ] At the top of this Issue, under ' Add a title', replace "[NAME]" with your name
+  - [ ] Assign yourself to this issue using the gear in the right sidebar
+  - [ ] Under `Labels`, replace `role: missing` label with `role: design`
+  - [ ] Under `Projects`, add issue to `Expunge Assist Project Tracking` using the gear in the sidebar
+  - [ ] move to `In Progress (active)` column
+  - [ ] Under `Milestones` move to `Team Workflow` using the gear in the sidebar
+
+- [ ] Add yourself to the Slack channels
+
+  - [ ] #expunge-assist
+  - [ ] #expunge-assist-design-content
+  - [ ] #expunge-assist-research-team
+  - [ ] #expunge-assist-dev
+
+- [ ] Introduce yourself on #expunge-assist Slack channel
+
+  - Include name, role in the team, where you're from, and what brings you to EA.
+
+- [ ] Ensure you have edit access to tools
+  - [ ] Add yourself to the [Google Drive Team Roster](https://docs.google.com/spreadsheets/d/12sAwYiQJP4fmEONF6-oUVYFVupTwSkci/edit)
+  - [ ] Reach out to the Design team leadership (lead or PM) to get Github, Drive, and Figma access
+    - Check the [Wiki Roster](https://github.com/hackforla/expunge-assist/wiki/The-Current-Team) to find leadership
+    - Slack is often the easiest way to contact them
+  - [ ] Ensure you have edit access to [Figma](https://www.figma.com/files/project/27345011?fuid=874019376796639084)
+    - Sign-up for a Figma account if you don't have one
+  - [ ] Ensure you have edit access to [Google Drive](https://drive.google.com/drive/u/0/folders/1qR-5gm7a-3h-Zm6Tu8IxDQ6yL488kf1n)
+  - [ ] Ensure you have edit access to [GitHub](https://github.com/hackforla/expunge-assist/projects/1)
+  - [ ] Ensure you have Google calendar invites to the following meetings:
+    - [ ] Design meetings
+    - [ ] Design/Content/ Research meetings
+    - [ ] All-Team meetings
+
+## Project Familiarization
+
+### Action Items
+
+- [ ] Learn the history, purpose, and EA's current roadmap
+  - [ ] Read our project's [One Page](https://docs.google.com/document/d/1SVgk4vH02oH7kUVbphKebrWMQNOMtzkIkpcksnHAULo/edit)
+  - [ ] Explore [EA's Wiki](https://github.com/hackforla/expunge-assist/wiki)
+  - [ ] Visit the [Design Team's Wiki](https://github.com/hackforla/expunge-assist/wiki/UX-Designer)
+- [ ] Review past and most current research
+  - [ ] [Internal Usability Testing 1 ](https://docs.google.com/document/d/1N0u7c1RwbxglQpLk_lIgbhDnAenMhCwNPazcNHI9aJI/edit?tab=t.0#heading=h.gpri51glck6b)
+  - [ ] [Internal Usability Testing 2 ](https://docs.google.com/presentation/d/1PH0c-MvX4HKfiEI9xZHUMM9YJFjGNsplaMNsCNbWqzI/edit#slide=id.geed4b67c62_0_0)
+  - [ ] [Personas/Target audience demographics](https://docs.google.com/presentation/d/1Bwl-tzVmd3xIZX5vLFmNKkwjylSExFImo2RMIqvsS0g/edit#slide=id.p)
+- [ ] Learn [how our team collaborates and how we take an issue from beginning to end](https://www.figma.com/file/hYqRxmBVtJbDv9DJXV6nra/Expunge-Assist-Main-Figma?type=design&node-id=11920-9931&mode=design&t=fJwnNvbDR2UVisY1-4)
+- [ ] Explore and use [expungeassist.org](https://expungeassist.org/)
+  - [ ] Make notes/screenshots of areas of improvements/bugs that the team can address
+  - [ ] Bring suggestions to Design team meeting or share with a Design Lead
+- [ ] Attend your first meetings
+  - [ ] Wednesdays 5 pm - 6 pm PST (Design meeting)
+  - [ ] Fridays 9:30am - 10:30 am PST (Content/Design/Research meeting)
+  - if you are unable to make either meeting, reach out to a design lead to work out a solution
+
+## GitHub 101
+
+GitHub is a web-based and open-source platform used for version control and collaboration on software development projects. It provides tools for developers to host and review code, manage projects, and build software together. Although Developers are mostly known to use GitHub, Hack for LA and our team use GitHub for project management and documentation.
+
+### Action Items
+
+- [ ] Review markdown and learn as best you can - language GitHub uses
+  - [ ] [Tutorial ](https://www.markdowntutorial.com/)
+  - [ ] [Cheatsheet](https://greenido.wordpress.com/2015/09/08/markdown-cheatsheet-101/)
+- [ ] Familiarize yourself with using a [Kanban board](https://docs.google.com/document/d/11Fe7mNdmPBP5bD_yLJ1C0_I1TmoK47AuHHrdhdDyWCs/edit#heading=h.nl3p4nf4eqb4)
+- [ ] Review [how our team uses GitHub](https://docs.google.com/document/d/1KuNrH_yKli4gvjdSF7DkPi0GtUArh2axYMJip6LlPFA/edit)
+- [ ] Read the About Section of [How To Create Issues](https://github.com/hackforla/expunge-assist/wiki/How-to-Create-Issues#About) to get an understanding of our how our issues are built
+- [ ] Learn [How to add an image file on GitHub](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/attaching-files)
+
+## Your first issue
+
+Now that you are familiar with our project and learned a bit about using our tools, it's time to work on your first Issue. I
+
+t's important to note to practice the following:
+
+- Most of our issues are 1pt, but do occasionally get higher than that. Start small and work your way up
+- Frequently add updates to all issues you are assigned to or providing input to
+  - updates are required once a week and should use the following format:
+
+```
+1. Progress
+2. Blockers
+3. Availability
+4. ETA
+```
+
+- Make sure to check off 'Action Items' as they are completed
+- Make sure to close issues as you finish them
+
+### Action Items
+
+- [ ] Go to our Project Board
+- [ ] Look under "Prioritized Backlog" on Project Board
+- [ ] Filter board using 'good first issue' label
+  - Talk to Design lead or PM if there are no design issues with that label
+- [ ] Assign yourself to issue
+- [ ] Move issue to "In Progress" column on Project Board
+
+## Team Resources
+
+#### Stuff You Should Bookmark
+
+- [Expunge Assist Figma](https://www.figma.com/file/hYqRxmBVtJbDv9DJXV6nra/Expunge-Assist-Main-Figma?type=design&node-id=2-21&mode=design&t=gp9ORTk5A0xuk3TF-0)
+- [Expunge Assist Google Drive](https://drive.google.com/drive/folders/1qR-5gm7a-3h-Zm6Tu8IxDQ6yL488kf1n?usp=sharing)
+- [GitHub Project Board](https://github.com/hackforla/expunge-assist/projects/1) - No filter
+- [GitHub Project Board ](https://github.com/hackforla/expunge-assist/projects/1?card_filter_query=label:%22role:+design%22)- Role: design filter
+- GitHub Issues Assigned to you
+  - Visit [Filter page](https://github.com/hackforla/UI-UX/issues)
+  - Under 'Assignees', click your name
+  - Bookmark that page
+- [Expunge Assist Website ](https://expungeassist.org/)
+- [EA Wiki ](https://github.com/hackforla/expunge-assist/wiki)
+- [Personas/Target audience demographics](https://docs.google.com/presentation/d/1Bwl-tzVmd3xIZX5vLFmNKkwjylSExFImo2RMIqvsS0g/edit#slide=id.p)


### PR DESCRIPTION
Fixes #1188 

### Changes made
- Added new template design-self-onboard.md to .github/ISSUE_TEMPLATE folder

### Reason for changes
- Instead of using one general issue to document and track a Designer's onboarding journey, the Design team would like an issue template developed so that new UI/UX Designers and Leads can track onboarding progress. Once all action items are completed, the ui/ux designer will close the issue and begin working on an issue for the current milestone.