### PR TITLE
Fix initial focus on finalize form page

### DIFF
--- a/products/statement-generator/src/components/TextPreview.tsx
+++ b/products/statement-generator/src/components/TextPreview.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useState, useRef, useEffect } from 'react';
 
 import { makeStyles, createStyles } from '@material-ui/core';
 import CreateIcon from '@material-ui/icons/Create';
@@ -41,17 +41,28 @@ interface ComponentProps {
   nameOfStep: string;
   className?: string;
   style?: object;
+  isFirstPreview?: boolean;
 }
 
 const TextPreview = forwardRef<HTMLDivElement, ComponentProps>(
-  ({ onSaveClick, content, nameOfStep, className = '', style }, ref) => {
+  (
+    { onSaveClick, content, nameOfStep, className = '', style, isFirstPreview },
+    ref
+  ) => {
     const classes = useStyles();
     const utilityClasses = useUtilityStyles();
     const [isEditing, setIsEditing] = useState<boolean>(false);
+    const editIconRef = useRef<SVGSVGElement | null>(null);
 
     const handleClick = () => {
       setIsEditing(true);
     };
+
+    useEffect(() => {
+      if (isFirstPreview && editIconRef.current) {
+        editIconRef.current.focus();
+      }
+    }, [isFirstPreview]);
 
     return (
       <div
@@ -77,6 +88,7 @@ const TextPreview = forwardRef<HTMLDivElement, ComponentProps>(
                     e.preventDefault();
                   }
                 }}
+                ref={editIconRef}
               />
             )}
           </div>

--- a/products/statement-generator/src/pages-form/FinalizeForm.tsx
+++ b/products/statement-generator/src/pages-form/FinalizeForm.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef } from 'react';
+import React, { useContext, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { makeStyles, createStyles } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
@@ -19,8 +19,6 @@ import {
   PREVIEW_MAP,
   PREVIEW_KEYS,
 } from 'helpers/previewHelper';
-
-import { AffirmationContext } from 'contexts/AffirmationContext';
 
 const useStyles = makeStyles(({ palette, spacing }) =>
   createStyles({
@@ -48,21 +46,7 @@ function FinalizeForm() {
   const classes = useStyles();
   const { formState, updateStepToForm } = useContext(FormStateContext);
 
-  const { affirmationData } = useContext(AffirmationContext);
-
   const previewsContainerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!affirmationData.isActive) {
-      const firstFocusableElement = previewsContainerRef.current?.querySelector(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="0"])'
-      );
-
-      if (firstFocusableElement instanceof HTMLElement) {
-        firstFocusableElement.focus();
-      }
-    }
-  }, [affirmationData.isActive]);
 
   function updatePreviewItem(newStatement: string, stateKey: string) {
     updateStepToForm({
@@ -73,7 +57,7 @@ function FinalizeForm() {
     });
   }
 
-  const previewComponents = PREVIEW_KEYS.map((previewKey) => {
+  const previewComponents = PREVIEW_KEYS.map((previewKey, index) => {
     const statement = getPreviewStatement(formState, previewKey as AppUrl);
     const isUnused = statement === '';
 
@@ -95,13 +79,14 @@ function FinalizeForm() {
             ? `${t('sections.previewing')} ${sectionTitle}`
             : `${t('sections.previewing')}: ${sectionTitle}`
         }
+        isFirstPreview={index === 0}
       />
     );
   });
 
   return (
     <ContentContainer>
-      <div className={classes.purpleTitle}>
+      <div className={classes.purpleTitle} tabIndex={-1}>
         <VisibilityIcon className={classes.purpleIcon} />
         Editing final letter
       </div>


### PR DESCRIPTION
Fixes #1229 

### Changes made
- Added optional `isFirstPreview` prop to indicate whether the `TextPreview` component in the `FinalizeForm` page is the first preview item
- Created a ref called `editIconRef` to reference the edit icon (`CreateIcon`) element
- Implemented useEffect to focus on the edit icon (`editIconRef`) when the component mounts and `isFirstPreview` is true -- this ensures that the first preview item's edit icon receives focus when the component is rendered

### Reason for changes
- Initial focus on the container is potentially confusing and not an a11y standard
- Enhances the overall user experience by ensuring that the focus follows a logical order
