### PR TITLE
1238 fix screen reader letter generator focus

### DIFF
--- a/products/statement-generator/src/components-layout/Affirmation.tsx
+++ b/products/statement-generator/src/components-layout/Affirmation.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useRef, useEffect, useContext } from 'react';
 import { Theme, createStyles, makeStyles } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import Dialog from '@material-ui/core/Dialog';
@@ -68,6 +68,13 @@ const Affirmation = () => {
   const backBtnTheme =
     appTheme === 'dark' ? 'transparent-on-dark' : 'transparent-on-light';
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
     <Dialog
       classes={
@@ -99,6 +106,8 @@ const Affirmation = () => {
       </div>
 
       <div
+        ref={contentContainerRef}
+        tabIndex={-1}
         className={`${utilityClasses.buttonContainer} ${
           utilityClasses.justifyRight
         } ${

--- a/products/statement-generator/src/components-layout/Affirmation.tsx
+++ b/products/statement-generator/src/components-layout/Affirmation.tsx
@@ -95,6 +95,8 @@ const Affirmation = () => {
       <img src={image} alt="affirmation illustration" />
 
       <div
+        ref={contentContainerRef}
+        tabIndex={-1}
         className={
           AppUrl.FinalizePreview === currentStep
             ? classes.doneMessageContainer
@@ -106,8 +108,6 @@ const Affirmation = () => {
       </div>
 
       <div
-        ref={contentContainerRef}
-        tabIndex={-1}
         className={`${utilityClasses.buttonContainer} ${
           utilityClasses.justifyRight
         } ${

--- a/products/statement-generator/src/components-layout/Affirmation.tsx
+++ b/products/statement-generator/src/components-layout/Affirmation.tsx
@@ -95,15 +95,19 @@ const Affirmation = () => {
       <img src={image} alt="affirmation illustration" />
 
       <div
-        ref={contentContainerRef}
-        tabIndex={-1}
         className={
           AppUrl.FinalizePreview === currentStep
             ? classes.doneMessageContainer
             : classes.messageContainer
         }
       >
-        <h2 className={classes.titleText}>{t(affirmationData.titleText)}</h2>
+        <h2
+          ref={contentContainerRef}
+          tabIndex={-1}
+          className={classes.titleText}
+        >
+          {t(affirmationData.titleText)}
+        </h2>
         <p>{t(affirmationData.description)}</p>
       </div>
 

--- a/products/statement-generator/src/components-layout/ContentContainer.tsx
+++ b/products/statement-generator/src/components-layout/ContentContainer.tsx
@@ -5,16 +5,18 @@ import useUtilityStyles from 'styles/utilityStyles';
 interface IContentContainer {
   children?: React.ReactNode;
   className?: string;
+  tabIndex?: number;
 }
 
 const ContentContainer = forwardRef<HTMLDivElement, IContentContainer>(
-  ({ children, className = '' }, ref) => {
+  ({ children, className = '', tabIndex }, ref) => {
     const utilityClasses = useUtilityStyles();
 
     return (
       <div
         ref={ref}
         className={`${utilityClasses.contentContainer} ${className}`}
+        tabIndex={tabIndex}
       >
         {children}
       </div>

--- a/products/statement-generator/src/components-layout/ContentContainer.tsx
+++ b/products/statement-generator/src/components-layout/ContentContainer.tsx
@@ -1,20 +1,25 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import useUtilityStyles from 'styles/utilityStyles';
 
 interface IContentContainer {
-  children?: any;
+  children?: React.ReactNode;
   className?: string;
 }
 
-const ContentContainer = ({ children, className = '' }: IContentContainer) => {
-  const utilityClasses = useUtilityStyles();
+const ContentContainer = forwardRef<HTMLDivElement, IContentContainer>(
+  ({ children, className = '' }, ref) => {
+    const utilityClasses = useUtilityStyles();
 
-  return (
-    <div className={`${utilityClasses.contentContainer} ${className}`}>
-      {children}
-    </div>
-  );
-};
+    return (
+      <div
+        ref={ref}
+        className={`${utilityClasses.contentContainer} ${className}`}
+      >
+        {children}
+      </div>
+    );
+  }
+);
 
 export default ContentContainer;

--- a/products/statement-generator/src/components-layout/FlowNavigation.tsx
+++ b/products/statement-generator/src/components-layout/FlowNavigation.tsx
@@ -24,6 +24,7 @@ interface IFlowNavigation {
   nextButtonLabel?: string;
   onBack?: () => void;
   onNext?: () => void;
+  focusRef?: React.RefObject<HTMLElement>;
   showBack?: boolean;
   showNext?: boolean;
 }
@@ -35,6 +36,7 @@ export default function FlowNavigation({
   nextButtonLabel,
   onBack,
   onNext,
+  focusRef,
   showBack = true,
   showNext = true,
 }: IFlowNavigation) {
@@ -64,6 +66,10 @@ export default function FlowNavigation({
     } else {
       goNextStep();
     }
+    // Focus the next page's main container after the navigation action
+    setTimeout(() => {
+      focusRef?.current?.focus();
+    }, 100); // A slight delay may be necessary to ensure the next component is ready
   };
 
   const handleNextButtonKeyDown = (

--- a/products/statement-generator/src/components-layout/FlowNavigation.tsx
+++ b/products/statement-generator/src/components-layout/FlowNavigation.tsx
@@ -24,7 +24,6 @@ interface IFlowNavigation {
   nextButtonLabel?: string;
   onBack?: () => void;
   onNext?: () => void;
-  focusRef?: React.RefObject<HTMLElement>;
   showBack?: boolean;
   showNext?: boolean;
 }
@@ -36,7 +35,6 @@ export default function FlowNavigation({
   nextButtonLabel,
   onBack,
   onNext,
-  focusRef,
   showBack = true,
   showNext = true,
 }: IFlowNavigation) {
@@ -66,10 +64,6 @@ export default function FlowNavigation({
     } else {
       goNextStep();
     }
-    // Focus the next page's main container after the navigation action
-    setTimeout(() => {
-      focusRef?.current?.focus();
-    }, 100); // A slight delay may be necessary to ensure the next component is ready
   };
 
   const handleNextButtonKeyDown = (

--- a/products/statement-generator/src/components/Input.tsx
+++ b/products/statement-generator/src/components/Input.tsx
@@ -88,6 +88,7 @@ interface InputFieldProps {
   adornment?: string;
   className?: string;
   shortWidth?: boolean; // if true, element will have a set width
+  labelRef?: React.Ref<HTMLLabelElement>;
 }
 
 const InputArea: React.FC<InputFieldProps> = ({
@@ -101,6 +102,7 @@ const InputArea: React.FC<InputFieldProps> = ({
   adornment,
   className = '',
   shortWidth = false,
+  labelRef,
 }) => {
   const utilityClasses = useUtilityStyles();
   const classes = useStyles({
@@ -115,7 +117,13 @@ const InputArea: React.FC<InputFieldProps> = ({
 
   return (
     <div className={`${utilityClasses.formInput} ${className}`}>
-      <InputLabel htmlFor={id} disabled={disabled}>
+      <InputLabel
+        tabIndex={0}
+        disabled={disabled}
+        ref={labelRef}
+        aria-label={label}
+        htmlFor={id}
+      >
         {label}
       </InputLabel>
 
@@ -141,6 +149,7 @@ const InputArea: React.FC<InputFieldProps> = ({
             {valid ? <CheckCircleIcon className={classes.icon} /> : null}
           </InputAdornment>
         }
+        autoComplete="off"
       />
     </div>
   );

--- a/products/statement-generator/src/components/TextPreview.tsx
+++ b/products/statement-generator/src/components/TextPreview.tsx
@@ -59,27 +59,36 @@ interface ComponentProps {
 }
 
 const TextPreview = forwardRef<HTMLDivElement, ComponentProps>(
-  (
-    { onSaveClick, content, nameOfStep, className = '', style, isFirstPreview },
-    ref
-  ) => {
+  ({
+    onSaveClick,
+    content,
+    nameOfStep,
+    className = '',
+    style,
+    isFirstPreview,
+  }) => {
     const classes = useStyles();
     const utilityClasses = useUtilityStyles();
     const [isEditing, setIsEditing] = useState<boolean>(false);
     const editButtonRef = useRef<HTMLButtonElement | null>(null);
+    const previewContainerRef = useRef<HTMLDivElement | null>(null);
 
     const handleClick = () => {
       setIsEditing(true);
     };
 
     useEffect(() => {
-      if (isFirstPreview && editButtonRef.current) {
-        editButtonRef.current.focus();
+      if (isFirstPreview && previewContainerRef.current) {
+        previewContainerRef.current.focus();
       }
     }, [isFirstPreview]);
 
     return (
-      <div ref={ref} className={`${classes.root} ${className}`} style={style}>
+      <div
+        ref={previewContainerRef}
+        className={`${classes.root} ${className}`}
+        style={style}
+      >
         <div className={classes.previewHeader}>
           <h3>{nameOfStep}</h3>
 
@@ -90,6 +99,7 @@ const TextPreview = forwardRef<HTMLDivElement, ComponentProps>(
                 onClick={handleClick}
                 aria-label="Edit content"
                 ref={editButtonRef}
+                tabIndex={0}
               >
                 <CreateIcon />
               </button>

--- a/products/statement-generator/src/components/TextPreview.tsx
+++ b/products/statement-generator/src/components/TextPreview.tsx
@@ -32,6 +32,20 @@ const useStyles = makeStyles(({ palette, spacing }) =>
         marginLeft: spacing(1),
       },
     },
+    editButton: {
+      background: 'none',
+      border: 'none',
+      cursor: 'pointer',
+      padding: spacing(1),
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: palette.primary.main,
+      '&:focus': {
+        outline: 'none',
+        boxShadow: `0 0 0 2px ${palette.primary.main}`,
+      },
+    },
   })
 );
 
@@ -52,44 +66,33 @@ const TextPreview = forwardRef<HTMLDivElement, ComponentProps>(
     const classes = useStyles();
     const utilityClasses = useUtilityStyles();
     const [isEditing, setIsEditing] = useState<boolean>(false);
-    const editIconRef = useRef<SVGSVGElement | null>(null);
+    const editButtonRef = useRef<HTMLButtonElement | null>(null);
 
     const handleClick = () => {
       setIsEditing(true);
     };
 
     useEffect(() => {
-      if (isFirstPreview && editIconRef.current) {
-        editIconRef.current.focus();
+      if (isFirstPreview && editButtonRef.current) {
+        editButtonRef.current.focus();
       }
     }, [isFirstPreview]);
 
     return (
-      <div
-        ref={ref}
-        className={`${classes.root} ${className}`}
-        style={style}
-        tabIndex={-1}
-      >
+      <div ref={ref} className={`${classes.root} ${className}`} style={style}>
         <div className={classes.previewHeader}>
           <h3>{nameOfStep}</h3>
 
           <div className={classes.actionHeader}>
             {!isEditing && (
-              <CreateIcon
-                className={`${utilityClasses.iconButton} create-icon-focusable`}
+              <button
+                className={`${utilityClasses.iconButton} ${classes.editButton}`}
                 onClick={handleClick}
-                tabIndex={0}
-                role="button"
                 aria-label="Edit content"
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    handleClick();
-                    e.preventDefault();
-                  }
-                }}
-                ref={editIconRef}
-              />
+                ref={editButtonRef}
+              >
+                <CreateIcon />
+              </button>
             )}
           </div>
         </div>

--- a/products/statement-generator/src/components/Textarea.tsx
+++ b/products/statement-generator/src/components/Textarea.tsx
@@ -76,6 +76,7 @@ interface TextFieldProps {
   disabled?: boolean;
   value?: string;
   rows?: number;
+  labelRef?: React.Ref<HTMLLabelElement>;
 }
 
 const MultilineTextFields = React.forwardRef<HTMLDivElement, TextFieldProps>(
@@ -89,6 +90,7 @@ const MultilineTextFields = React.forwardRef<HTMLDivElement, TextFieldProps>(
       disabled = false,
       value,
       rows,
+      labelRef,
     },
     ref
   ) => {
@@ -98,7 +100,13 @@ const MultilineTextFields = React.forwardRef<HTMLDivElement, TextFieldProps>(
     return (
       <div className={utilityClasses.formInput}>
         {label && (
-          <InputLabel htmlFor={id} disabled={disabled}>
+          <InputLabel
+            ref={labelRef}
+            aria-label={label}
+            htmlFor={id}
+            disabled={disabled}
+            tabIndex={0}
+          >
             {label}
           </InputLabel>
         )}
@@ -119,6 +127,7 @@ const MultilineTextFields = React.forwardRef<HTMLDivElement, TextFieldProps>(
             notched: false,
           }}
           inputRef={ref}
+          autoComplete="off"
         />
       </div>
     );

--- a/products/statement-generator/src/pages-form/Advice.tsx
+++ b/products/statement-generator/src/pages-form/Advice.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { makeStyles, createStyles } from '@material-ui/core';
 import CancelIcon from '@material-ui/icons/Cancel';
@@ -68,9 +68,15 @@ const useStyles = makeStyles(({ breakpoints }) =>
 export default function Advice() {
   const { t } = useTranslation();
   const classes = useStyles();
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
 
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <h2 className={classes.title}>{t('advice_page.header')}</h2>
       <div>
         <p className={classes.text}>{t('advice_page.point1.content')}</p>

--- a/products/statement-generator/src/pages-form/Advice.tsx
+++ b/products/statement-generator/src/pages-form/Advice.tsx
@@ -68,16 +68,18 @@ const useStyles = makeStyles(({ breakpoints }) =>
 export default function Advice() {
   const { t } = useTranslation();
   const classes = useStyles();
-  const contentContainerRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
     // Automatically focus the container when the component mounts
-    contentContainerRef.current?.focus();
+    titleRef.current?.focus();
   }, []);
 
   return (
-    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
-      <h2 className={classes.title}>{t('advice_page.header')}</h2>
+    <ContentContainer>
+      <h2 ref={titleRef} tabIndex={-1} className={classes.title}>
+        {t('advice_page.header')}
+      </h2>
       <div>
         <p className={classes.text}>{t('advice_page.point1.content')}</p>
         <div className={classes.yesNoContainer}>

--- a/products/statement-generator/src/pages-form/BeforeYouBegin.tsx
+++ b/products/statement-generator/src/pages-form/BeforeYouBegin.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { makeStyles, createStyles } from '@material-ui/core';
 
@@ -96,9 +96,16 @@ const useStyles = makeStyles(({ palette, breakpoints }) =>
 const BeforeYouBegin = () => {
   const classes = useStyles();
   const { t } = useTranslation();
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (contentContainerRef.current) {
+      contentContainerRef.current.focus();
+    }
+  }, []);
 
   return (
-    <ContentContainer className={classes.root}>
+    <ContentContainer ref={contentContainerRef} className={classes.root}>
       <h3>{t('before_you_begin_page.header')}</h3>
 
       <h6>{t('before_you_begin_page.sectionTitle1')}</h6>

--- a/products/statement-generator/src/pages-form/BeforeYouBegin.tsx
+++ b/products/statement-generator/src/pages-form/BeforeYouBegin.tsx
@@ -99,13 +99,16 @@ const BeforeYouBegin = () => {
   const contentContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (contentContainerRef.current) {
-      contentContainerRef.current.focus();
-    }
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
   }, []);
 
   return (
-    <ContentContainer ref={contentContainerRef} className={classes.root}>
+    <ContentContainer
+      ref={contentContainerRef}
+      tabIndex={-1}
+      className={classes.root}
+    >
       <h3>{t('before_you_begin_page.header')}</h3>
 
       <h6>{t('before_you_begin_page.sectionTitle1')}</h6>

--- a/products/statement-generator/src/pages-form/BeforeYouBegin.tsx
+++ b/products/statement-generator/src/pages-form/BeforeYouBegin.tsx
@@ -96,20 +96,18 @@ const useStyles = makeStyles(({ palette, breakpoints }) =>
 const BeforeYouBegin = () => {
   const classes = useStyles();
   const { t } = useTranslation();
-  const contentContainerRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
     // Automatically focus the container when the component mounts
-    contentContainerRef.current?.focus();
+    titleRef.current?.focus();
   }, []);
 
   return (
-    <ContentContainer
-      ref={contentContainerRef}
-      tabIndex={-1}
-      className={classes.root}
-    >
-      <h3>{t('before_you_begin_page.header')}</h3>
+    <ContentContainer className={classes.root}>
+      <h3 ref={titleRef} tabIndex={-1}>
+        {t('before_you_begin_page.header')}
+      </h3>
 
       <h6>{t('before_you_begin_page.sectionTitle1')}</h6>
       <p

--- a/products/statement-generator/src/pages-form/Download.tsx
+++ b/products/statement-generator/src/pages-form/Download.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useRef, useEffect, useState, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { saveAs } from 'file-saver';
 import { Document, Packer, Paragraph } from 'docx';
@@ -138,8 +138,15 @@ export default function Download({ onDownloadAgreementCheck }: IDownload) {
     doc.save('MyPersonalStatement.pdf');
   };
 
+  const contentContainerRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <form>
+    <form ref={contentContainerRef} tabIndex={-1}>
       <Checkbox
         checked={!isDisabled}
         onChange={handleClickCheck}

--- a/products/statement-generator/src/pages-form/FinalizeForm.tsx
+++ b/products/statement-generator/src/pages-form/FinalizeForm.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useRef } from 'react';
+import React, { useContext, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { makeStyles, createStyles } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
@@ -84,8 +84,15 @@ function FinalizeForm() {
     );
   });
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <div className={classes.purpleTitle} tabIndex={-1}>
         <VisibilityIcon className={classes.purpleIcon} />
         Editing final letter

--- a/products/statement-generator/src/pages-form/FinalizePreview.tsx
+++ b/products/statement-generator/src/pages-form/FinalizePreview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useRef, useEffect, useContext, useState } from 'react';
 import { makeStyles, createStyles } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 
@@ -52,8 +52,15 @@ function FinalizeStep() {
   const [disableNext, setDisableNext] = useState(true);
   const { updateAffirmationData } = useContext(AffirmationContext);
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <div className={classes.purpleTitle}>
         <VisibilityIcon className={classes.purpleIcon} />
         {t('finalize_preview.header_title')}

--- a/products/statement-generator/src/pages-form/GoalsStep.tsx
+++ b/products/statement-generator/src/pages-form/GoalsStep.tsx
@@ -8,22 +8,12 @@ import FlowNavigation from 'components-layout/FlowNavigation';
 import ContentContainer from 'components-layout/ContentContainer';
 import Textarea from 'components/Textarea';
 
-import { AffirmationContext } from 'contexts/AffirmationContext';
-
 function GoalsStep() {
   const { t } = useTranslation();
   const { formState, updateStepToForm } = useContext(FormStateContext);
   const { goals, goalsHow } = formState.goalsState;
 
-  const { affirmationData } = useContext(AffirmationContext);
-
   const goalsRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (!affirmationData.isActive) {
-      goalsRef.current?.focus();
-    }
-  }, [affirmationData.isActive]);
 
   const goalsValid = goals !== '';
   const goalsHowValid = goalsHow !== '';

--- a/products/statement-generator/src/pages-form/GoalsStep.tsx
+++ b/products/statement-generator/src/pages-form/GoalsStep.tsx
@@ -37,8 +37,15 @@ function GoalsStep() {
     });
   };
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <Textarea
         ref={goalsRef}
         id="goals"

--- a/products/statement-generator/src/pages-form/IntroductionStep.tsx
+++ b/products/statement-generator/src/pages-form/IntroductionStep.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useRef, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import FormStateContext from 'contexts/FormStateContext';
@@ -27,8 +27,15 @@ export function IntroductionStep() {
     });
   };
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <FormContainer>
         <Input
           id="fullName"

--- a/products/statement-generator/src/pages-form/IntroductionStep.tsx
+++ b/products/statement-generator/src/pages-form/IntroductionStep.tsx
@@ -27,15 +27,15 @@ export function IntroductionStep() {
     });
   };
 
-  const contentContainerRef = useRef<HTMLDivElement>(null);
+  const fullNameLabelRef = useRef<HTMLLabelElement>(null);
 
   useEffect(() => {
     // Automatically focus the container when the component mounts
-    contentContainerRef.current?.focus();
+    fullNameLabelRef.current?.focus();
   }, []);
 
   return (
-    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
+    <ContentContainer>
       <FormContainer>
         <Input
           id="fullName"
@@ -45,6 +45,7 @@ export function IntroductionStep() {
           shortWidth
           handleChange={onInputChange}
           type="text"
+          labelRef={fullNameLabelRef}
         />
 
         <Input

--- a/products/statement-generator/src/pages-form/InvolvementCommunityServiceFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementCommunityServiceFlow.tsx
@@ -31,15 +31,15 @@ function InvolvementCommunityServiceFlow() {
     });
   };
 
-  const contentContainerRef = useRef<HTMLDivElement>(null);
+  const serviceLabelRef = useRef<HTMLLabelElement>(null);
 
   useEffect(() => {
     // Automatically focus the container when the component mounts
-    contentContainerRef.current?.focus();
+    serviceLabelRef.current?.focus();
   }, []);
 
   return (
-    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
+    <ContentContainer>
       <FormContainer>
         <Input
           id="organizationName"
@@ -51,6 +51,7 @@ function InvolvementCommunityServiceFlow() {
           defaultValue={organizationName}
           shortWidth
           type="text"
+          labelRef={serviceLabelRef}
         />
 
         <Textarea

--- a/products/statement-generator/src/pages-form/InvolvementCommunityServiceFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementCommunityServiceFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useRef, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import FormStateContext from 'contexts/FormStateContext';
@@ -31,8 +31,15 @@ function InvolvementCommunityServiceFlow() {
     });
   };
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <FormContainer>
         <Input
           id="organizationName"

--- a/products/statement-generator/src/pages-form/InvolvementInitialFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementInitialFlow.tsx
@@ -74,8 +74,15 @@ function InvolvementInitialFlow() {
     });
   };
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <FormContainer>
         <FormControl className={classes.checkboxGroup}>
           <FormLabel htmlFor="involvement-checkboxes">

--- a/products/statement-generator/src/pages-form/InvolvementInitialFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementInitialFlow.tsx
@@ -7,8 +7,6 @@ import { useTranslation } from 'react-i18next';
 
 import FormStateContext from 'contexts/FormStateContext';
 
-import { AffirmationContext } from 'contexts/AffirmationContext';
-
 import Checkbox from 'components/Checkbox';
 
 import ContentContainer from 'components-layout/ContentContainer';
@@ -35,14 +33,12 @@ const useStyles = makeStyles<Theme>(({ palette, spacing }) =>
 function InvolvementInitialFlow() {
   const { t } = useTranslation();
   const classes = useStyles();
-  const { affirmationData } = useContext(AffirmationContext);
-  const firstCheckboxRef = useRef<HTMLInputElement>(null);
+  const contentContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!affirmationData.isActive) {
-      firstCheckboxRef.current?.focus();
-    }
-  }, [affirmationData.isActive]);
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
 
   const { formState, updateStepToForm } = useContext(FormStateContext);
   const {
@@ -74,13 +70,6 @@ function InvolvementInitialFlow() {
     });
   };
 
-  const contentContainerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    // Automatically focus the container when the component mounts
-    contentContainerRef.current?.focus();
-  }, []);
-
   return (
     <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <FormContainer>
@@ -90,7 +79,7 @@ function InvolvementInitialFlow() {
           </FormLabel>
           <FormGroup id="involvement-checkboxes">
             <Checkbox
-              ref={firstCheckboxRef}
+              // ref={firstCheckboxRef}
               useTeal
               id="isJobChecked"
               checked={isJobChecked}

--- a/products/statement-generator/src/pages-form/InvolvementJobFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementJobFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useRef, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import FormStateContext from 'contexts/FormStateContext';
@@ -33,8 +33,15 @@ function InvolvementJobFlow() {
     });
   };
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <FormContainer>
         <Input
           id="companyName"

--- a/products/statement-generator/src/pages-form/InvolvementJobFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementJobFlow.tsx
@@ -33,15 +33,15 @@ function InvolvementJobFlow() {
     });
   };
 
-  const contentContainerRef = useRef<HTMLDivElement>(null);
+  const companyNameLabelRef = useRef<HTMLLabelElement>(null);
 
   useEffect(() => {
     // Automatically focus the container when the component mounts
-    contentContainerRef.current?.focus();
+    companyNameLabelRef.current?.focus();
   }, []);
 
   return (
-    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
+    <ContentContainer>
       <FormContainer>
         <Input
           id="companyName"
@@ -51,6 +51,7 @@ function InvolvementJobFlow() {
           defaultValue={companyName}
           shortWidth
           type="text"
+          labelRef={companyNameLabelRef}
         />
 
         <Input

--- a/products/statement-generator/src/pages-form/InvolvementParentingFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementParentingFlow.tsx
@@ -27,15 +27,15 @@ function InvolvementParentingFlow() {
     });
   };
 
-  const contentContainerRef = useRef<HTMLDivElement>(null);
+  const parentLabelRef = useRef<HTMLLabelElement>(null);
 
   useEffect(() => {
     // Automatically focus the container when the component mounts
-    contentContainerRef.current?.focus();
+    parentLabelRef.current?.focus();
   }, []);
 
   return (
-    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
+    <ContentContainer>
       <FormContainer>
         <Input
           id="numberChildren"
@@ -44,6 +44,7 @@ function InvolvementParentingFlow() {
           placeholder="0"
           handleChange={onInputChange}
           defaultValue={numberChildren}
+          labelRef={parentLabelRef}
         />
 
         <Textarea

--- a/products/statement-generator/src/pages-form/InvolvementParentingFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementParentingFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useRef, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import FormStateContext from 'contexts/FormStateContext';
@@ -27,8 +27,15 @@ function InvolvementParentingFlow() {
     });
   };
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <FormContainer>
         <Input
           id="numberChildren"

--- a/products/statement-generator/src/pages-form/InvolvementRecoveryFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementRecoveryFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useRef, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import FormStateContext from 'contexts/FormStateContext';
@@ -27,8 +27,15 @@ function InvolvementRecoveryFlow() {
     });
   };
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <FormContainer>
         <Input
           id="recoveryName"

--- a/products/statement-generator/src/pages-form/InvolvementRecoveryFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementRecoveryFlow.tsx
@@ -27,15 +27,15 @@ function InvolvementRecoveryFlow() {
     });
   };
 
-  const contentContainerRef = useRef<HTMLDivElement>(null);
+  const recoveryLabelRef = useRef<HTMLLabelElement>(null);
 
   useEffect(() => {
     // Automatically focus the container when the component mounts
-    contentContainerRef.current?.focus();
+    recoveryLabelRef.current?.focus();
   }, []);
 
   return (
-    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
+    <ContentContainer>
       <FormContainer>
         <Input
           id="recoveryName"
@@ -45,6 +45,7 @@ function InvolvementRecoveryFlow() {
           defaultValue={recoveryName}
           shortWidth
           type="text"
+          labelRef={recoveryLabelRef}
         />
 
         <Textarea

--- a/products/statement-generator/src/pages-form/InvolvementSchoolFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementSchoolFlow.tsx
@@ -29,15 +29,15 @@ function InvolvementSchoolFlow() {
     });
   };
 
-  const contentContainerRef = useRef<HTMLDivElement>(null);
+  const schoolLabelRef = useRef<HTMLLabelElement>(null);
 
   useEffect(() => {
     // Automatically focus the container when the component mounts
-    contentContainerRef.current?.focus();
+    schoolLabelRef.current?.focus();
   }, []);
 
   return (
-    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
+    <ContentContainer>
       <FormContainer>
         <Input
           id="schoolName"
@@ -47,6 +47,7 @@ function InvolvementSchoolFlow() {
           defaultValue={schoolName}
           shortWidth
           type="text"
+          labelRef={schoolLabelRef}
         />
 
         <Input

--- a/products/statement-generator/src/pages-form/InvolvementSchoolFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementSchoolFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useRef, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import FormStateContext from 'contexts/FormStateContext';
@@ -29,8 +29,15 @@ function InvolvementSchoolFlow() {
     });
   };
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <FormContainer>
         <Input
           id="schoolName"

--- a/products/statement-generator/src/pages-form/InvolvementSomethingElseFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementSomethingElseFlow.tsx
@@ -28,15 +28,15 @@ function InvolvementSomethingElseFlow() {
     });
   };
 
-  const contentContainerRef = useRef<HTMLDivElement>(null);
+  const somethingElseLabelRef = useRef<HTMLLabelElement>(null);
 
   useEffect(() => {
     // Automatically focus the container when the component mounts
-    contentContainerRef.current?.focus();
+    somethingElseLabelRef.current?.focus();
   }, []);
 
   return (
-    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
+    <ContentContainer>
       <FormContainer>
         <Input
           id="activityName"
@@ -45,6 +45,7 @@ function InvolvementSomethingElseFlow() {
           handleChange={onInputChange}
           defaultValue={activityName}
           type="text"
+          labelRef={somethingElseLabelRef}
         />
 
         <Textarea

--- a/products/statement-generator/src/pages-form/InvolvementSomethingElseFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementSomethingElseFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useRef, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import FormStateContext from 'contexts/FormStateContext';
@@ -28,8 +28,15 @@ function InvolvementSomethingElseFlow() {
     });
   };
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <FormContainer>
         <Input
           id="activityName"

--- a/products/statement-generator/src/pages-form/InvolvementUnemploymentFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementUnemploymentFlow.tsx
@@ -25,15 +25,15 @@ function InvolvementUnemploymentFlow() {
     });
   };
 
-  const contentContainerRef = useRef<HTMLDivElement>(null);
+  const unemploymentLabelRef = useRef<HTMLLabelElement>(null);
 
   useEffect(() => {
     // Automatically focus the container when the component mounts
-    contentContainerRef.current?.focus();
+    unemploymentLabelRef.current?.focus();
   }, []);
 
   return (
-    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
+    <ContentContainer>
       <FormContainer>
         <Textarea
           id="unemploymentDescription"
@@ -44,6 +44,7 @@ function InvolvementUnemploymentFlow() {
           defaultValue={unemploymentDescription}
           handleChange={onInputChange}
           rows={3}
+          labelRef={unemploymentLabelRef}
         />
       </FormContainer>
 

--- a/products/statement-generator/src/pages-form/InvolvementUnemploymentFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementUnemploymentFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useRef, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import FormStateContext from 'contexts/FormStateContext';
@@ -25,8 +25,15 @@ function InvolvementUnemploymentFlow() {
     });
   };
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <FormContainer>
         <Textarea
           id="unemploymentDescription"

--- a/products/statement-generator/src/pages-form/Welcome.tsx
+++ b/products/statement-generator/src/pages-form/Welcome.tsx
@@ -28,11 +28,11 @@ const useStyles = makeStyles<Theme>(({ palette, spacing, globals }) =>
 export default function Welcome() {
   const { t } = useTranslation();
   const classes = useStyles();
-  const contentContainerRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
     // Focus the container when the page loads
-    contentContainerRef.current?.focus();
+    titleRef.current?.focus();
   }, []);
 
   return (
@@ -45,8 +45,10 @@ export default function Welcome() {
         />
       </div>
 
-      <ContentContainer ref={contentContainerRef} tabIndex={-1}>
-        <h1>{t('welcome_page.titleText')}</h1>
+      <ContentContainer>
+        <h1 ref={titleRef} tabIndex={-1}>
+          {t('welcome_page.titleText')}
+        </h1>
 
         <p>{t('welcome_page.description')}</p>
 

--- a/products/statement-generator/src/pages-form/Welcome.tsx
+++ b/products/statement-generator/src/pages-form/Welcome.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { Theme, createStyles, makeStyles } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 
@@ -28,6 +28,13 @@ const useStyles = makeStyles<Theme>(({ palette, spacing, globals }) =>
 export default function Welcome() {
   const { t } = useTranslation();
   const classes = useStyles();
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (contentContainerRef.current) {
+      contentContainerRef.current.focus();
+    }
+  }, []);
 
   return (
     <>
@@ -39,7 +46,7 @@ export default function Welcome() {
         />
       </div>
 
-      <ContentContainer>
+      <ContentContainer ref={contentContainerRef}>
         <h1>{t('welcome_page.titleText')}</h1>
 
         <p>{t('welcome_page.description')}</p>

--- a/products/statement-generator/src/pages-form/Welcome.tsx
+++ b/products/statement-generator/src/pages-form/Welcome.tsx
@@ -31,9 +31,8 @@ export default function Welcome() {
   const contentContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (contentContainerRef.current) {
-      contentContainerRef.current.focus();
-    }
+    // Focus the container when the page loads
+    contentContainerRef.current?.focus();
   }, []);
 
   return (
@@ -46,7 +45,7 @@ export default function Welcome() {
         />
       </div>
 
-      <ContentContainer ref={contentContainerRef}>
+      <ContentContainer ref={contentContainerRef} tabIndex={-1}>
         <h1>{t('welcome_page.titleText')}</h1>
 
         <p>{t('welcome_page.description')}</p>

--- a/products/statement-generator/src/pages-form/WhyStep.tsx
+++ b/products/statement-generator/src/pages-form/WhyStep.tsx
@@ -38,8 +38,15 @@ function WhyStep() {
     });
   };
 
+  const contentContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Automatically focus the container when the component mounts
+    contentContainerRef.current?.focus();
+  }, []);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       <FormContainer>
         <Textarea
           ref={whyRef}

--- a/products/statement-generator/src/pages-form/WhyStep.tsx
+++ b/products/statement-generator/src/pages-form/WhyStep.tsx
@@ -9,22 +9,12 @@ import ContentContainer from 'components-layout/ContentContainer';
 import FlowNavigation from 'components-layout/FlowNavigation';
 import FormContainer from 'components-layout/FormContainer';
 
-import { AffirmationContext } from 'contexts/AffirmationContext';
-
 function WhyStep() {
   const { t } = useTranslation();
   const { formState, updateStepToForm } = useContext(FormStateContext);
   const { clearRecordWhy, clearRecordHow } = formState.whyState;
 
-  const { affirmationData } = useContext(AffirmationContext);
-
   const whyRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (!affirmationData.isActive) {
-      whyRef.current?.focus();
-    }
-  }, [affirmationData.isActive]);
 
   const clearRecordWhyValid = clearRecordWhy !== '';
   const clearRecordHowValid = clearRecordHow !== '';

--- a/products/statement-generator/src/pages/PreviewPage.tsx
+++ b/products/statement-generator/src/pages/PreviewPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect } from 'react';
+import React, { useCallback, useContext, useEffect, useRef } from 'react';
 
 import TextPreview from 'components/TextPreview';
 import ContentContainer from 'components-layout/ContentContainer';
@@ -15,6 +15,7 @@ function PreviewPage() {
   const { currentStep } = useContext(RoutingContext);
   const previewConfigItem = getPreviewConfig(currentStep);
   const hasPreviewConfig = previewConfigItem !== undefined;
+  const contentContainerRef = useRef<HTMLDivElement>(null);
 
   const updateStatement = useCallback((newStatement: string) => {
     if (hasPreviewConfig) {
@@ -25,6 +26,11 @@ function PreviewPage() {
         },
       });
     }
+  }, []);
+
+  useEffect(() => {
+    // Focus the container when the page loads
+    contentContainerRef.current?.focus();
   }, []);
 
   // hacky implementation to generate the heading & closing statement here
@@ -48,7 +54,7 @@ function PreviewPage() {
   }, [currentStep]);
 
   return (
-    <ContentContainer>
+    <ContentContainer ref={contentContainerRef} tabIndex={-1}>
       {hasPreviewConfig && (
         <TextPreview
           onSaveClick={updateStatement}


### PR DESCRIPTION
Fixes #1238 

### Changes made
1. In `ContentContainer.tsx`:
- Updated component to use `forwardRef` to allow passing a `ref` to the container `div`
- Added a `tabIndex` prop to allow setting the `tabIndex` attribute on the container `div`
- Passed the `ref` and `tabIndex` props to the container `div`

2. In all of the necessary form pages and component files:
- Created a `contentContainerRef` using `useRef` to reference the `ContentContainer` component
- Added a `useEffect` hook to automatically focus the `ContentContainer` when the component mounts
- Passed the `contentContainerRef` as the ref prop to the `ContentContainer` component
- Added `tabIndex={-1}` to the `ContentContainer` component to make it focusable

3. In `TextPreview.tsx`:
- Replaced the `CreateIcon` component with a native `button` element because screen readers will not focus on the MUI `CreateIcon` (this change enhances the semantic correctness and accessibility, making the interactive element more recognizable to screen readers)
- Added `aria-label` to provide a clear description of the button's purpose for screen readers
- Updated the `ref` to use `editButtonRef` instead of `editIconRef`
- Removed the `tabIndex` and `onKeyDown` event handler from the button, as they are not necessary for a native button element

### Reason for changes
- Screen reader focus stayed on the "Next" button after using it to navigate to the next page of the form
- These changes improve the accessibility of the app by ensuring that the relevant containers and elements are focusable and can be navigated using a screen reader. The `tabIndex={-1}` attribute allows the containers to be programmatically focused, while the `useEffect` hook automatically focuses the container when the component mounts.