### PR TITLE
Create blank-issue-dependency.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue-dependency.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue-dependency.md
@@ -1,0 +1,24 @@
+---
+name: Blank Issue w/ Dependency
+about: Consistent formatting make issues concise and easy to navigate
+title: ''
+labels: 'feature: missing, priority: missing, role: missing, size: missing, dependency, issue level: missing'
+assignees: ''
+
+---
+
+### Dependency
+- [ ] add number of issue blocking this one ex`#...`
+
+### Overview
+REPLACE THIS TEXT - Text here that clearly states the purpose and context of this issue 
+
+### Action Items
+- [ ] REPLACE THIS TEXT - If this is the beginning of the task this is most likely something to be researched and documented.
+- [ ] REPLACE THIS TEXT - If the issue has already been researched, and the course of action is clear, this will describe the steps.  However, if the steps can be divided into tasks for more than one person, we recommend dividing it up into separate issues, or assigning it as a pair programming task.
+
+IF BLOCKING ANOTHER ISSUE:
+- [ ] remove dependency on #BLOCKED_ISSUE and move it to `New Issues waiting for approval` on the project board
+
+### Resources/Notes
+REPLACE THIS TEXT - If there is a website which has documentation that helps with this issue provide the link(s) here.`


### PR DESCRIPTION
Closes #1091 

### Changes Made:
Add new `blank-issue-dependency.md` template. 

### Reason for changes:
We're re-organizing how we write issues to include dependencies. To make writing issues more efficient, we want to create a template for issues with dependencies.