### PR TITLE
1316 Add GHA to automate weekly label check for issues

### DIFF
--- a/.github/workflows/scripts/weekly-label-check.js
+++ b/.github/workflows/scripts/weekly-label-check.js
@@ -1,0 +1,109 @@
+const { Octokit } = require("@octokit/rest");
+
+// Create Octokit instance
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+const REQUIRED_LABELS = ["priority", "role", "feature", "size"];
+const LABEL_MISSING = [
+  "priority: missing",
+  "role: missing",
+  "feature: missing",
+  "size: missing",
+];
+
+async function fetchOpenIssues() {
+  let allIssues = [];
+  let hasNextPage = true;
+  let currentPage = 1;
+
+  while (hasNextPage) {
+    const { data: issues } = await octokit.issues.listForRepo({
+      owner: "hackforla",
+      repo: "expunge-assist",
+      state: "open", // Only fetch open issues
+      page: currentPage,
+      per_page: 100, // You can increase per_page if needed (up to 100)
+    });
+
+    allIssues = allIssues.concat(issues); // Combine results from all pages
+
+    hasNextPage = issues.length === 100; // Check if there's a next page
+    currentPage++;
+  }
+
+  const allOpenIssues = allIssues.filter(
+    (issue) => issue.pull_request === undefined
+  );
+  console.log("Fetched all open issues (excluding PRs):", allOpenIssues.length);
+  return allOpenIssues;
+}
+
+// Main function to process open issues
+async function main() {
+  const openIssues = await fetchOpenIssues();
+  // console.log(openIssues.length);
+
+  for (const issue of openIssues) {
+    const labels = issue.labels.map((label) => label.name);
+    const filteredLabels = filterLabels(labels);
+    const labelsToAdd = checkLabels(filteredLabels);
+
+    if (labelsToAdd.length === 0) {
+      console.log(
+        `All required labels are included for issue #${issue.number}; no labels to add.`
+      );
+    } else {
+      console.log(`Labels to add for issue #${issue.number}: `, labelsToAdd);
+      await addLabels(labelsToAdd, issue.number);
+    }
+  }
+}
+
+function filterLabels(labels) {
+  return labels.filter((label) => LABEL_MISSING.includes(label) === false);
+}
+
+function checkLabels(labels) {
+  let labelsToAdd = [];
+
+  REQUIRED_LABELS.forEach((requiredLabel, i) => {
+    const regExp = new RegExp(`${requiredLabel}`, "gi");
+    const isLabelPresent = labels.some((label) => {
+      return regExp.test(label);
+    });
+
+    if (isLabelPresent === false) {
+      labelsToAdd.push(LABEL_MISSING[i]);
+    }
+  });
+
+  return labelsToAdd;
+}
+
+async function addLabels(
+  labelsToAdd,
+  issueNum,
+  owner = "hackforla",
+  repo = "expunge-assist"
+) {
+  const labels = [...new Set([...labelsToAdd])];
+
+  try {
+    await octokit.issues.addLabels({
+      owner: owner,
+      repo: repo,
+      issue_number: issueNum,
+      labels: labels,
+    });
+    if (labelsToAdd.length > 0) {
+      console.log("Successfully added labels to issue #", issueNum);
+    }
+    return true;
+  } catch (err) {
+    console.error("Error editing labels: ", err);
+    return false;
+  }
+}
+
+// Call main function
+main().catch(console.error);

--- a/.github/workflows/scripts/weekly-label-check.js
+++ b/.github/workflows/scripts/weekly-label-check.js
@@ -1,15 +1,11 @@
 const { Octokit } = require("@octokit/rest");
 
-// Create Octokit instance
 const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 
-const REQUIRED_LABELS = ["priority", "role", "feature", "size"];
-const LABEL_MISSING = [
-  "priority: missing",
-  "role: missing",
-  "feature: missing",
-  "size: missing",
-];
+const REQUIRED_LABELS = ["priority", "role", "feature", "size", "issue level"];
+const LABEL_MISSING = REQUIRED_LABELS.map((label) => {
+  return `${label}: missing`;
+});
 
 async function fetchOpenIssues() {
   let allIssues = [];
@@ -74,7 +70,6 @@ function checkLabels(labels) {
       labelsToAdd.push(LABEL_MISSING[i]);
     }
   });
-
   return labelsToAdd;
 }
 
@@ -103,5 +98,4 @@ async function addLabels(
   }
 }
 
-// Call main function
 main().catch(console.error);

--- a/.github/workflows/scripts/weekly-label-check.js
+++ b/.github/workflows/scripts/weekly-label-check.js
@@ -20,14 +20,14 @@ async function fetchOpenIssues() {
     const { data: issues } = await octokit.issues.listForRepo({
       owner: "hackforla",
       repo: "expunge-assist",
-      state: "open", // Only fetch open issues
+      state: "open",
       page: currentPage,
-      per_page: 100, // You can increase per_page if needed (up to 100)
+      per_page: 100,
     });
 
-    allIssues = allIssues.concat(issues); // Combine results from all pages
+    allIssues = allIssues.concat(issues);
 
-    hasNextPage = issues.length === 100; // Check if there's a next page
+    hasNextPage = issues.length === 100;
     currentPage++;
   }
 
@@ -38,10 +38,8 @@ async function fetchOpenIssues() {
   return allOpenIssues;
 }
 
-// Main function to process open issues
 async function main() {
   const openIssues = await fetchOpenIssues();
-  // console.log(openIssues.length);
 
   for (const issue of openIssues) {
     const labels = issue.labels.map((label) => label.name);

--- a/.github/workflows/weekly-label-check.yml
+++ b/.github/workflows/weekly-label-check.yml
@@ -1,0 +1,30 @@
+name: Weekly Label Check
+
+on:
+  schedule:
+    # Runs every Sunday at 00:00 UTC
+    - cron: "0 0 * * 0"
+
+jobs:
+  Add-Missing-Labels-To-Issues:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install @octokit/rest
+
+      - name: Process Open Issues
+        run: node ./.github/workflows/scripts/weekly-label-check.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #1316 

Quick note - while testing this locally with Act, I actually applied “priority: missing” labels to 4 issues. Glad it worked properly, but sorry about that 😅 I’ll look into why that happened.

**Changes made**: Added a GitHub Action that runs on Sundays and filters through open issues in the repo, adding missing labels where necessary. 

**Reason for changes**: Currently the weekly label check is really onerous. You have to go link by link to update and add `missing` labels to all the issues missing any of the required labels.

I emulated the website team’s GHA setup here for a similar workflow that runs when an issue is opened or assigned:
- Wiki page [here](https://github.com/hackforla/website/wiki/Hack-for-LA's-GitHub-Actions)
- .yml [here](https://github.com/hackforla/website/blob/gh-pages/.github/workflows/issue-trigger.yml)
- .js [here](https://github.com/hackforla/website/blob/gh-pages/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js)

‘What do you think about adding a function to comment on the issues like they have [here](https://github.com/hackforla/website/blob/gh-pages/github-actions/trigger-issue/add-missing-labels-to-issues/add-labels-template.md)?