### PR TITLE
1377 Apply Prettier GHA to only the Dev Branch

### DIFF
--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -1,6 +1,8 @@
 name: Prettier Lint
 
-on: [pull_request]
+on:
+  pull_request:
+    branches: [dev]
 
 jobs:
   prettier:

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -2,7 +2,8 @@ name: Prettier Lint
 
 on:
   pull_request:
-    branches: [dev]
+    branches:
+      - dev
 
 jobs:
   prettier:

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -1,12 +1,10 @@
 name: Prettier Lint
 
-on:
-  pull_request:
-    branches:
-      - dev
+on: [pull_request]
 
 jobs:
   prettier:
+    if: github.event.pull_request.head.ref != 'dev'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Fixes #1377 

### Changes made
Updated prettier-check.yml to only run on pull requests to dev by adding 
```
if: github.event.pull_request.head.ref != 'dev'
```
### Reason for changes
Currently the check runs both on the PR into the dev branch AND the PR into main. This second check is unnecessary since dev is used as a staging environment and we don't make changes directly to dev. To reduce redundancy, we only want to run the check once, on the PR from issue branches into dev.