### PR TITLE
1106 Add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,8 +2,7 @@
 name: Bug Report
 about: Report a bug to help us improve Expunge Assist
 title: '[BUG]'
-labels: 'feature: missing, priority: high, role: missing, size: missing, bug'
-assignees: sydneywalcoff
+labels: 'feature: missing, priority: high, role: missing, size: missing, bug, ready for dev lead'
 ---
 
 ### What is the bug you're reporting?

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug Report
 about: Report a bug to help us improve Expunge Assist
-title: "[BUG]"
-labels: "feature: missing, priority: high, role: missing, size: missing, bug"
+title: '[BUG]'
+labels: 'feature: missing, priority: high, role: missing, size: missing, bug'
 assignees: sydneywalcoff
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+about: Report a bug to help us improve Expunge Assist
+title: "[BUG]"
+labels: "feature: missing, priority: high, role: missing, size: missing, bug"
+assignees: sydneywalcoff
+---
+
+### What is the bug you're reporting?
+
+REPLACE THIS TEXT - Describe the bug to the best of your ability.
+
+### Where did you find the bug?
+
+REPLACE THIS TEXT - Describe the location or paste a link.
+
+### When did you first notice this bug?
+
+REPLACE THIS TEXT - Date/time, your best guess is fine
+
+### What browser do you use?
+
+REPLACE THIS TEXT - Safari/Chrome/Firefox/Opera/etc
+
+### What kind of device did you notice this bug on?
+
+REPLACE THIS TEXT - ex: iPhone 11 or Windows PC
+
+### What operating system are you running?
+
+REPLACE THIS TEXT - ex: macOS Monterey
+
+### Do you have any screenshots or videos of the bug?
+
+### Action Items
+
+- [ ] ... to be filled out by the Dev Lead
+
+### Resources/Notes
+
+REPLACE THIS TEXT - If there is documentation or tutorials that may help with this issue, provide the link(s) here.


### PR DESCRIPTION
Fixes: #1106 

### Changes made:
Added bug report issue template that will add a high priority label to the issue and assign it to the dev lead.

### Reason for changes:
As the EA team grows and new developers are introduced, bugs become more likely. To simplify the process of reporting and solving a bug, we want to include all relevant details about the reporter's environment.