### PR TITLE
381 Affirmation popup

### DIFF
--- a/products/statement-generator/src/components-layout/Affirmation.tsx
+++ b/products/statement-generator/src/components-layout/Affirmation.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useContext } from 'react';
+import React, { useContext, useRef, useEffect } from 'react';
 import { Theme, createStyles, makeStyles } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import Dialog from '@material-ui/core/Dialog';

--- a/products/statement-generator/src/contexts/AffirmationContext.tsx
+++ b/products/statement-generator/src/contexts/AffirmationContext.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useContext, useEffect } from 'react';
-
 import { AppUrl } from 'contexts/RoutingProps';
 import RoutingContext from 'contexts/RoutingContext';
 
@@ -7,11 +6,7 @@ import FutureGoalsImg from 'assets/future-goals-img.svg';
 import WhyImg from 'assets/why-img.svg';
 import AlmostThereImg from 'assets/almost-there-img.svg';
 
-// TODO: its kind of confusing that the data is which url this should show up
-//  as opposed to the step that it is referring to
 const AFFIRMATION_DATA = {
-  // even though it is on the Involvement page,
-  //  this is to thank new users after the Introduction
   [AppUrl.Involvement as string]: {
     titleText: 'affirmation_popup.step2.titleText',
     description: 'affirmation_popup.step2.description',
@@ -61,28 +56,37 @@ const AffirmationContextProvider = ({ children }: AffirmationProviderProps) => {
     description: 'affirmation_popup.step2.description',
   });
 
-  const updateAffirmationData = (newState: object) => {
-    setAffirmationData({ ...affirmationData, ...newState });
+  const [affirmationShown, setAffirmationShown] = useState<{
+    [key: string]: boolean;
+  }>({});
+
+  const updateAffirmationData = (newState: Partial<AffirmationProps>) => {
+    setAffirmationData((prevState) => ({ ...prevState, ...newState }));
   };
 
   useEffect(() => {
     const newData = AFFIRMATION_DATA[currentStep as string];
 
-    if (newData !== undefined) {
+    if (newData && canShowAffirmation && !affirmationShown[currentStep]) {
       updateAffirmationData({
         ...newData,
-        isActive: canShowAffirmation,
+        isActive: true,
       });
+      setAffirmationShown((prev) => ({ ...prev, [currentStep]: true }));
     } else {
       updateAffirmationData({
         isActive: false,
       });
     }
-  }, [currentStep]);
+  }, [currentStep, canShowAffirmation]);
 
   return (
     <AffirmationContext.Provider
-      value={{ affirmationData, setAffirmationData, updateAffirmationData }}
+      value={{
+        affirmationData,
+        setAffirmationData,
+        updateAffirmationData,
+      }}
     >
       {children}
     </AffirmationContext.Provider>

--- a/products/statement-generator/src/contexts/FormStateContext.tsx
+++ b/products/statement-generator/src/contexts/FormStateContext.tsx
@@ -1,5 +1,4 @@
-import React, { createContext, useContext, useState } from 'react';
-
+import React, { createContext, useContext, useState, useEffect } from 'react';
 import {
   IStepState,
   defaultStepState,
@@ -19,6 +18,7 @@ export const FormStateContextProvider = ({
   children,
 }: FormStateProviderProps) => {
   const [formState, setFormState] = useState<IStepState>(defaultStepState);
+  const [stepShown, setStepShown] = useState<{ [key: string]: boolean }>({});
 
   const updateStepToForm = (stepState: any) =>
     setFormState({ ...formState, ...stepState });
@@ -104,7 +104,7 @@ export const FormStateContextProvider = ({
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     // initiate the event handler
     window.addEventListener('keydown', test);
 
@@ -114,6 +114,13 @@ export const FormStateContextProvider = ({
     };
   });
 
+  useEffect(() => {
+    if (!stepShown[currentStep]) {
+      setStepShown((prev) => ({ ...prev, [currentStep]: true }));
+      // Add any specific logic that should only run once per step here
+    }
+  }, [currentStep, stepShown]);
+
   return (
     <FormStateContext.Provider
       value={{
@@ -121,6 +128,8 @@ export const FormStateContextProvider = ({
         updateStepToForm,
         goNextStep,
         goBackStep,
+        stepShown,
+        setStepShown,
       }}
     >
       {children}


### PR DESCRIPTION
Fixes: #381 

### Changes made: 
Adjusted Affirmation component with a useEffect hook and also AffirmationContext and FormStateContext files to track if certain data matches the current step.

### Reason for changes:
Affirmations should show once during the form process, if a user goes back a step and then forward again the popup should not happen again. 
