### PR TITLE
1345 Add scroll-to-top to react-router

### DIFF
--- a/products/statement-generator/src/App.tsx
+++ b/products/statement-generator/src/App.tsx
@@ -4,7 +4,6 @@ import { ThemeProvider } from '@material-ui/core/styles';
 
 import { RoutingContextProvider } from 'contexts/RoutingContext';
 import { AppUrl } from 'contexts/RoutingProps';
-
 import AffirmationContextProvider from 'contexts/AffirmationContext';
 import { FormStateContextProvider } from 'contexts/FormStateContext';
 

--- a/products/statement-generator/src/App.tsx
+++ b/products/statement-generator/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@material-ui/core/styles';
 
 import { RoutingContextProvider } from 'contexts/RoutingContext';
 import { AppUrl } from 'contexts/RoutingProps';
+
 import AffirmationContextProvider from 'contexts/AffirmationContext';
 import { FormStateContextProvider } from 'contexts/FormStateContext';
 
@@ -43,6 +44,7 @@ import 'styles/App.css';
 import customMuiTheme from 'styles/customMuiTheme';
 
 import { useTranslation } from 'react-i18next';
+import ScrollToTop from './components-layout/ScrollToTop';
 
 const App: React.FC = () => {
   const { i18n } = useTranslation();
@@ -55,6 +57,7 @@ const App: React.FC = () => {
     <ThemeProvider theme={customMuiTheme}>
       <Router basename={`${process.env.PUBLIC_URL}/`}>
         <RoutingContextProvider>
+          <ScrollToTop />
           <AffirmationContextProvider>
             <FormStateContextProvider>
               <nav

--- a/products/statement-generator/src/components-layout/ScrollToTop.tsx
+++ b/products/statement-generator/src/components-layout/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
Fixes #1345

### Changes made: 
Created ScrollToTop component, added component to App.tsx

### Reason for changes:
React-router's default functionality is to preserve your scroll position upon navigating to different routes. We're updating this to auto-scroll-to-top for better UX.
