### PR TITLE
1418 Update Footer HfLA copyright year dynamically

### DIFF
--- a/products/statement-generator/src/components-layout/AppFooter.tsx
+++ b/products/statement-generator/src/components-layout/AppFooter.tsx
@@ -146,7 +146,9 @@ function HackForLACopyright() {
           alt="Link to Hack for LA site"
         />
       </a>
-      <span className={classes.reg}>© 2022 Hack for LA</span>
+      <span className={classes.reg}>
+        © {new Date().getFullYear().toString()} Hack for LA
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
Fixes: #1418 

### Changes made: 
Corrected the copyright year to update dynamically

### Reason for changes:
We need the HfLA copyright year in the footer to reflect the current year