### PR TITLE
1247 Textarea testing

### DIFF
--- a/products/statement-generator/src/tests/textareas.test.tsx
+++ b/products/statement-generator/src/tests/textareas.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+
 import { ThemeProvider } from '@material-ui/core/styles';
 import customMuiTheme from 'styles/customMuiTheme';
 
@@ -20,6 +22,21 @@ describe('Textarea component', () => {
   });
 
   test('Textarea props are passed correctly', () => {
+    interface ExpectedProps {
+      placeholder: string;
+      id: string;
+      rows: string;
+    }
+
+    const checkTextareaProps = (
+      input: HTMLElement,
+      expectedProps: ExpectedProps
+    ) => {
+      expect(input).toHaveAttribute('placeholder', expectedProps.placeholder);
+      expect(input).toHaveAttribute('rows', expectedProps.rows);
+      expect(input).toHaveAttribute('id', expectedProps.id);
+    };
+
     const { getByText, rerender } = render(
       <ThemeProvider theme={customMuiTheme}>
         <Textarea
@@ -35,14 +52,12 @@ describe('Textarea component', () => {
 
     const textarea = getByText(/Type here/i);
 
-    // passed correct placeholder
-    expect(textarea).toHaveAttribute('placeholder', 'Type here');
-
-    // passed correct # of rows
-    expect(textarea).toHaveAttribute('rows', '3');
-
-    // passed correct id
-    expect(textarea).toHaveAttribute('id', 'test');
+    // passed correct placeholder, # of rows, and id
+    checkTextareaProps(textarea, {
+      placeholder: 'Type here',
+      rows: '3',
+      id: 'test',
+    });
 
     // passed correct label
     const label = getByText('label');
@@ -86,8 +101,12 @@ describe('Textarea component', () => {
     expect(label).toHaveAttribute('for', 'accessible-textarea');
 
     // textarea is focusable
-    const textarea = getByPlaceholderText('Type here');
-    textarea.focus();
-    expect(textarea).toHaveFocus();
+    const input = getByPlaceholderText('Type here');
+    userEvent.click(input);
+    expect(input).toHaveFocus();
+
+    // textarea does not trap focus
+    userEvent.tab();
+    expect(input).not.toHaveFocus();
   });
 });

--- a/products/statement-generator/src/tests/textareas.test.tsx
+++ b/products/statement-generator/src/tests/textareas.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider } from '@material-ui/core/styles';
+import customMuiTheme from 'styles/customMuiTheme';
+
+import Textarea from '../components/Textarea';
+
+describe('Textarea component', () => {
+  test('Textarea renders and displays correct default value', () => {
+    const { getByText } = render(
+      <ThemeProvider theme={customMuiTheme}>
+        <Textarea id="test" handleChange={() => {}} defaultValue="Type here" />
+      </ThemeProvider>
+    );
+
+    const textarea = getByText(/Type here/i);
+
+    expect(textarea).toBeInTheDocument();
+  });
+
+  test('Textarea props are passed correctly', () => {
+    const { getByText, rerender } = render(
+      <ThemeProvider theme={customMuiTheme}>
+        <Textarea
+          id="test"
+          label="label"
+          placeholder="Type here"
+          handleChange={() => {}}
+          defaultValue="Type here"
+          rows={3}
+        />
+      </ThemeProvider>
+    );
+
+    const textarea = getByText(/Type here/i);
+
+    // passed correct placeholder
+    expect(textarea).toHaveAttribute('placeholder', 'Type here');
+
+    // passed correct # of rows
+    expect(textarea).toHaveAttribute('rows', '3');
+
+    // passed correct id
+    expect(textarea).toHaveAttribute('id', 'test');
+
+    // passed correct label
+    const label = getByText('label');
+    expect(label).toBeInTheDocument();
+    expect(label).toHaveAttribute('for', 'test');
+
+    // passed disabled state correctly
+    rerender(
+      <ThemeProvider theme={customMuiTheme}>
+        <Textarea
+          id="test"
+          label="label"
+          handleChange={() => {}}
+          defaultValue="Type here"
+          rows={3}
+          disabled
+        />
+      </ThemeProvider>
+    );
+
+    expect(textarea).toBeDisabled();
+  });
+
+  test('Textarea is accessible and focusable', () => {
+    const { getByText, getByPlaceholderText } = render(
+      <ThemeProvider theme={customMuiTheme}>
+        <Textarea
+          id="accessible-textarea"
+          label="accessibleTextarea"
+          placeholder="Type here"
+          handleChange={() => {}}
+          defaultValue=""
+          rows={3}
+        />
+      </ThemeProvider>
+    );
+
+    // label is associated with the textarea
+    const label = getByText('accessibleTextarea');
+    expect(label).toBeInTheDocument();
+    expect(label).toHaveAttribute('for', 'accessible-textarea');
+
+    // textarea is focusable
+    const textarea = getByPlaceholderText('Type here');
+    textarea.focus();
+    expect(textarea).toHaveFocus();
+  });
+});

--- a/products/statement-generator/src/tests/textareas.test.tsx
+++ b/products/statement-generator/src/tests/textareas.test.tsx
@@ -94,8 +94,6 @@ describe('Textarea component', () => {
           label="accessibleTextarea"
           placeholder="Type here"
           handleChange={() => {}}
-          defaultValue=""
-          rows={3}
         />
       </ThemeProvider>
     );

--- a/products/statement-generator/src/tests/textareas.test.tsx
+++ b/products/statement-generator/src/tests/textareas.test.tsx
@@ -32,9 +32,14 @@ describe('Textarea component', () => {
       input: HTMLElement,
       expectedProps: ExpectedProps
     ) => {
-      expect(input).toHaveAttribute('placeholder', expectedProps.placeholder);
-      expect(input).toHaveAttribute('rows', expectedProps.rows);
-      expect(input).toHaveAttribute('id', expectedProps.id);
+      const attributes: (keyof typeof expectedProps)[] = [
+        'placeholder',
+        'rows',
+        'id',
+      ];
+      attributes.forEach((attr) => {
+        expect(input).toHaveAttribute(attr, expectedProps[attr]);
+      });
     };
 
     const { getByText, rerender } = render(

--- a/products/statement-generator/src/tests/textareas.test.tsx
+++ b/products/statement-generator/src/tests/textareas.test.tsx
@@ -103,13 +103,19 @@ describe('Textarea component', () => {
     expect(label).toBeInTheDocument();
     expect(label).toHaveAttribute('for', 'accessible-textarea');
 
-    // textarea is focusable
+    // textarea and label focus on tab
     const input = getByPlaceholderText('Type here');
-    userEvent.click(input);
+    userEvent.tab();
+    expect(label).toHaveFocus();
+    userEvent.tab();
     expect(input).toHaveFocus();
 
     // textarea does not trap focus
     userEvent.tab();
     expect(input).not.toHaveFocus();
+
+    // textarea focuses on click
+    userEvent.click(input);
+    expect(input).toHaveFocus();
   });
 });


### PR DESCRIPTION
Fixes #1247 

### Changes made: 
Added tests for the following:
- textarea renders and displays the correct default value
- textarea props are passed correctly
- textarea is accessible and focusable

### Reason for changes:
We want to retroactively implement testing to better protect our codebase