### PR TITLE
1525 Update Welcome page bg color

### DIFF
--- a/products/statement-generator/src/contexts/RoutingContext.tsx
+++ b/products/statement-generator/src/contexts/RoutingContext.tsx
@@ -111,18 +111,6 @@ const PreRoutingContextProvider = ({
     }
   }, [pathname]);
 
-  // update `appTheme` depending on page
-  useEffect(() => {
-    switch (currentStep) {
-      case AppUrl.Welcome:
-        setAppTheme('pink');
-        break;
-      default:
-        setAppTheme('transparent');
-        break;
-    }
-  }, [currentStep]);
-
   return (
     <RoutingContext.Provider
       value={{

--- a/products/statement-generator/src/pages-form/Welcome.tsx
+++ b/products/statement-generator/src/pages-form/Welcome.tsx
@@ -7,7 +7,7 @@ import AffirmationImage from 'assets/affirmation-img.svg';
 import ContentContainer from 'components-layout/ContentContainer';
 import FlowNavigation from 'components-layout/FlowNavigation';
 
-const useStyles = makeStyles<Theme>(({ palette, spacing, globals }) =>
+const useStyles = makeStyles<Theme>(({ spacing, globals }) =>
   createStyles({
     illustrationContainer: {
       marginTop: spacing(3),
@@ -16,7 +16,6 @@ const useStyles = makeStyles<Theme>(({ palette, spacing, globals }) =>
       height: '400px',
     },
     illustration: {
-      background: palette.primary.lighter,
       width: globals.contentWidth,
       position: 'absolute',
       left: '50%',


### PR DESCRIPTION
Fixes #1525 

### Changes made: 
Update Welcome page background from #F7EBFF to #FFFFFF'

### Reason for changes:
Current background color doesn't match [Figma design](https://www.figma.com/design/hYqRxmBVtJbDv9DJXV6nra/Expunge-Assist-Main-Figma?node-id=8543-105399&t=91qpXWSorh218F6b-4)