### PR TITLE
1434 FAQ link color 

### DIFF
--- a/products/statement-generator/src/components/LinkAsText.tsx
+++ b/products/statement-generator/src/components/LinkAsText.tsx
@@ -1,15 +1,26 @@
 import React from 'react';
 import { makeStyles, createStyles, Link } from '@material-ui/core';
 
-const useStyles = makeStyles(({ palette }) =>
+const useStyles = makeStyles(() =>
   createStyles({
     linkAsText: {
-      color: palette.common.black,
+      color: '#25003F',
+      '&:visited': {
+        color: '#25003F', // Same color for visited links
+      },
+      '&:hover': {
+        color: '#25003F', // Same color on hover
+      },
     },
   })
 );
 
-export default function LinkAsText({ link }: any) {
+interface LinkAsTextProps {
+  link: string;
+  label?: string;
+}
+
+export default function LinkAsText({ link, label }: LinkAsTextProps) {
   const classes = useStyles();
   return (
     <>
@@ -19,8 +30,9 @@ export default function LinkAsText({ link }: any) {
         className={classes.linkAsText}
         href={link}
         target="_blank"
+        rel="noopener noreferrer"
       >
-        {link}
+        {label || link}
       </Link>
       &nbsp;
     </>


### PR DESCRIPTION
closes #1434 

### Changes made:
- Changed color to match figma design so the link doesn't change colors wether it has been clicked or not 

### Reasons for change:
- To match figma design