### PR TITLE
1434 FAQ link color

### DIFF
--- a/products/statement-generator/src/components/FAQAccordion.tsx
+++ b/products/statement-generator/src/components/FAQAccordion.tsx
@@ -14,15 +14,16 @@ interface CustomAccordionProps {
   content?: string[];
 }
 
-const useStyles = makeStyles(() =>
+const useStyles = makeStyles(({ palette }) =>
   createStyles({
     accordionWrapper: {
       width: '100%',
+      color: palette.primary.darker,
       boxShadow: 'none',
       border: 'none',
       position: 'static',
-      '& *': {
-        color: '#25003F',
+      '& a': {
+        color: palette.primary.darker,
       },
     },
     accordionSummary: {

--- a/products/statement-generator/src/components/FAQAccordion.tsx
+++ b/products/statement-generator/src/components/FAQAccordion.tsx
@@ -48,8 +48,7 @@ const useStyles = makeStyles(() =>
       padding: 0,
       width: '100%',
       paddingLeft: '40px',
-      '& p': {  
-},
+      '& p': {},
     },
   })
 );

--- a/products/statement-generator/src/components/FAQAccordion.tsx
+++ b/products/statement-generator/src/components/FAQAccordion.tsx
@@ -14,25 +14,29 @@ interface CustomAccordionProps {
   content?: string[];
 }
 
-const useStyles = makeStyles(({ palette }) =>
+const useStyles = makeStyles(() =>
   createStyles({
     accordionWrapper: {
       width: '100%',
-      color: palette.primary.darker,
+      color: '#25003F',
       boxShadow: 'none',
       border: 'none',
-      position: 'static', // when position is 'relative' or not specified a vertical line appears above the accordion (unclear why)
+      position: 'static',
+      '& *': {
+        color: '#25003F',
+      },
     },
     accordionSummary: {
       fontSize: '20px',
       lineHeight: '24px',
-      color: palette.primary.darker,
+      color: '#25003F',
     },
     expandIcon: {
       marginLeft: '0',
       marginRight: '16px',
       width: '24px',
       transition: 'transform 0.4s ease-in-out',
+      color: '#25003F',
     },
     rotateIcon: {
       transform: 'rotate(360deg)',
@@ -47,6 +51,9 @@ const useStyles = makeStyles(({ palette }) =>
       padding: 0,
       width: '100%',
       paddingLeft: '40px',
+      '& p': {
+        color: '#25003F',
+      },
     },
   })
 );
@@ -60,6 +67,7 @@ const AccordionSummary = styled((props: AccordionSummaryProps) => (
 
   '& .MuiAccordionSummary-content': {
     minHeight: 0,
+    color: '#25003F',
   },
 }));
 
@@ -94,7 +102,10 @@ export const FAQAccordion: React.FC<CustomAccordionProps> = ({
         <div className={classes.accordionDetailsContainer}>
           {content &&
             content.map((paragraph) => (
-              <Typography dangerouslySetInnerHTML={{ __html: t(paragraph) }} />
+              <Typography
+                key={`${title}-${paragraph}`}
+                dangerouslySetInnerHTML={{ __html: t(paragraph) }}
+              />
             ))}
           {children && children}
         </div>

--- a/products/statement-generator/src/components/FAQAccordion.tsx
+++ b/products/statement-generator/src/components/FAQAccordion.tsx
@@ -49,7 +49,6 @@ const useStyles = makeStyles(({ palette }) =>
       padding: 0,
       width: '100%',
       paddingLeft: '40px',
-      '& p': {},
     },
   })
 );

--- a/products/statement-generator/src/components/FAQAccordion.tsx
+++ b/products/statement-generator/src/components/FAQAccordion.tsx
@@ -18,7 +18,6 @@ const useStyles = makeStyles(() =>
   createStyles({
     accordionWrapper: {
       width: '100%',
-      color: '#25003F',
       boxShadow: 'none',
       border: 'none',
       position: 'static',
@@ -29,14 +28,12 @@ const useStyles = makeStyles(() =>
     accordionSummary: {
       fontSize: '20px',
       lineHeight: '24px',
-      color: '#25003F',
     },
     expandIcon: {
       marginLeft: '0',
       marginRight: '16px',
       width: '24px',
       transition: 'transform 0.4s ease-in-out',
-      color: '#25003F',
     },
     rotateIcon: {
       transform: 'rotate(360deg)',
@@ -51,9 +48,8 @@ const useStyles = makeStyles(() =>
       padding: 0,
       width: '100%',
       paddingLeft: '40px',
-      '& p': {
-        color: '#25003F',
-      },
+      '& p': {  
+},
     },
   })
 );
@@ -67,7 +63,6 @@ const AccordionSummary = styled((props: AccordionSummaryProps) => (
 
   '& .MuiAccordionSummary-content': {
     minHeight: 0,
-    color: '#25003F',
   },
 }));
 
@@ -102,10 +97,7 @@ export const FAQAccordion: React.FC<CustomAccordionProps> = ({
         <div className={classes.accordionDetailsContainer}>
           {content &&
             content.map((paragraph) => (
-              <Typography
-                key={`${title}-${paragraph}`}
-                dangerouslySetInnerHTML={{ __html: t(paragraph) }}
-              />
+              <Typography dangerouslySetInnerHTML={{ __html: t(paragraph) }} />
             ))}
           {children && children}
         </div>

--- a/products/statement-generator/src/components/LinkAsText.tsx
+++ b/products/statement-generator/src/components/LinkAsText.tsx
@@ -1,26 +1,15 @@
 import React from 'react';
 import { makeStyles, createStyles, Link } from '@material-ui/core';
 
-const useStyles = makeStyles(() =>
+const useStyles = makeStyles(({ palette }) =>
   createStyles({
     linkAsText: {
-      color: '#25003F',
-      '&:visited': {
-        color: '#25003F', // Same color for visited links
-      },
-      '&:hover': {
-        color: '#25003F', // Same color on hover
-      },
+      color: palette.common.black,
     },
   })
 );
 
-interface LinkAsTextProps {
-  link: string;
-  label?: string;
-}
-
-export default function LinkAsText({ link, label }: LinkAsTextProps) {
+export default function LinkAsText({ link }: any) {
   const classes = useStyles();
   return (
     <>
@@ -30,9 +19,8 @@ export default function LinkAsText({ link, label }: LinkAsTextProps) {
         className={classes.linkAsText}
         href={link}
         target="_blank"
-        rel="noopener noreferrer"
       >
-        {label || link}
+        {link}
       </Link>
       &nbsp;
     </>


### PR DESCRIPTION
Fixes reopened issue: #1434 

### Changes Made: Added CSS styling for all text in FAQ accordion to be the same color including the links, in all user states.

### Reason for changes: Match figma designs 