### PR TITLE
1248 Radio Button testing

### DIFF
--- a/products/statement-generator/src/tests/radiobuttons.test.tsx
+++ b/products/statement-generator/src/tests/radiobuttons.test.tsx
@@ -7,7 +7,6 @@ import { ThemeProvider } from '@material-ui/core/styles';
 import customMuiTheme from 'styles/customMuiTheme';
 
 import RadioGroup from '../components/RadioGroup';
-import { useRadioGroup } from '@material-ui/core';
 
 // create TestRadioGroup component in order to test state changes
 type Choice = 'Yes' | 'No';

--- a/products/statement-generator/src/tests/radiobuttons.test.tsx
+++ b/products/statement-generator/src/tests/radiobuttons.test.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from '@material-ui/core/styles';
 import customMuiTheme from 'styles/customMuiTheme';
 
 import RadioGroup from '../components/RadioGroup';
+import { useRadioGroup } from '@material-ui/core';
 
 // create TestRadioGroup component in order to test state changes
 type Choice = 'Yes' | 'No';
@@ -85,12 +86,12 @@ describe('Radio group component', () => {
   });
 
   test('Radio buttons are accessible and focusable', async () => {
-    const { getByLabelText } = render(
+    const { getByRole, getByLabelText } = render(
       <TestRadioGroup id="example" label="test" />
     );
 
+    const radioGroup = getByRole('radiogroup');
     const yesRadio = getByLabelText('Yes') as HTMLInputElement;
-    const noRadio = getByLabelText('No') as HTMLInputElement;
 
     // radio buttons are focusable
     userEvent.tab();
@@ -102,7 +103,6 @@ describe('Radio group component', () => {
 
     // radio buttons do not trap focus
     userEvent.tab();
-    expect(noRadio).toHaveFocus();
-    expect(yesRadio).not.toHaveFocus();
+    expect(radioGroup).not.toHaveFocus();
   });
 });

--- a/products/statement-generator/src/tests/radiobuttons.test.tsx
+++ b/products/statement-generator/src/tests/radiobuttons.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+
+import { ThemeProvider } from '@material-ui/core/styles';
+import customMuiTheme from 'styles/customMuiTheme';
+
+import RadioGroup from '../components/RadioGroup';
+
+// create TestRadioGroup component in order to test state changes
+type Choice = 'Yes' | 'No';
+
+export interface TestRadioGroupProps {
+  id: string;
+  label: string;
+}
+
+const radioButtonMock = jest.fn();
+
+const TestRadioGroup: React.FC<TestRadioGroupProps> = ({ id, label }) => {
+  const [selected, setSelected] = React.useState<Choice | null>(null);
+  const radioGroupChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value as Choice;
+    setSelected(newValue);
+    radioButtonMock();
+  };
+  return (
+    <ThemeProvider theme={customMuiTheme}>
+      <RadioGroup
+        id={id}
+        label={label}
+        value={selected ?? ''}
+        choices={['Yes', 'No']}
+        handleChange={radioGroupChange}
+      />
+    </ThemeProvider>
+  );
+};
+
+describe('Radio group component', () => {
+  test('Radio buttons render and display correct initial state', () => {
+    const { getByLabelText } = render(
+      <TestRadioGroup id="example" label="test" />
+    );
+
+    // radio buttons display correct labels
+    const yesRadio = getByLabelText('Yes') as HTMLInputElement;
+    const noRadio = getByLabelText('No') as HTMLInputElement;
+
+    expect(yesRadio).toBeInTheDocument();
+    expect(noRadio).toBeInTheDocument();
+
+    expect(yesRadio).not.toBeChecked();
+    expect(noRadio).not.toBeChecked();
+  });
+
+  test('Checkbox functions correctly', () => {
+    const { getByLabelText } = render(
+      <TestRadioGroup id="example" label="test" />
+    );
+
+    const yesRadio = getByLabelText('Yes') as HTMLInputElement;
+    const noRadio = getByLabelText('No') as HTMLInputElement;
+
+    // clicking radio button selects it
+    userEvent.click(yesRadio);
+    expect(yesRadio).toBeChecked();
+    expect(noRadio).not.toBeChecked();
+
+    // click second radio button selects it & deselects the first
+    userEvent.click(noRadio);
+    expect(noRadio).toBeChecked();
+    expect(yesRadio).not.toBeChecked();
+  });
+
+  test('Radio group props are passed correctly', () => {
+    const { getByRole } = render(<TestRadioGroup id="example" label="test" />);
+
+    const radioGroup = getByRole('radiogroup');
+
+    // id passed correctly
+    // label and choices props are checked in above tests
+    expect(radioGroup).toHaveAttribute('id', 'example');
+  });
+
+  test('Radio buttons are accessible and focusable', async () => {
+    const { getByLabelText } = render(
+      <TestRadioGroup id="example" label="test" />
+    );
+
+    const yesRadio = getByLabelText('Yes') as HTMLInputElement;
+    const noRadio = getByLabelText('No') as HTMLInputElement;
+
+    // radio buttons are focusable
+    userEvent.tab();
+    expect(yesRadio).toHaveFocus();
+
+    // pressing spacebar changes state
+    userEvent.type(yesRadio, ' ');
+    expect(yesRadio).toBeChecked();
+
+    // radio buttons do not trap focus
+    userEvent.tab();
+    expect(noRadio).toHaveFocus();
+    expect(yesRadio).not.toHaveFocus();
+  });
+});


### PR DESCRIPTION
Fixes #1248 

### Changes made: 
Knocked this one out since it's pretty similar to the checkbox testing. Added tests to check that radio buttons:
- set up correctly
- function properly
- are passed props correctly
- are accessible

### Reason for changes:
We want to retroactively implement testing to better protect our codebase