### PR TITLE
1558 h2 landing text

### DIFF
--- a/products/statement-generator/src/pages/Landing.tsx
+++ b/products/statement-generator/src/pages/Landing.tsx
@@ -49,8 +49,9 @@ const useStyles = makeStyles(({ globals, palette, breakpoints, spacing }) =>
       },
       '& h2': {
         fontWeight: '600',
+        fontSize: '1.5rem',
         [breakpoints.down(breakpoints.values.sm)]: {
-          textAlign: 'left',
+          textAlign: 'center',
           alignSelf: 'flex-start',
         },
       },

--- a/products/statement-generator/src/pages/Landing.tsx
+++ b/products/statement-generator/src/pages/Landing.tsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles(({ globals, palette, breakpoints, spacing }) =>
         fontWeight: '600',
         fontSize: '1.5rem',
         [breakpoints.down(breakpoints.values.sm)]: {
-          textAlign: 'center',
+          textAlign: 'left',
           alignSelf: 'flex-start',
         },
       },


### PR DESCRIPTION
fixes: #1558 

### Changes made: added `fontSize` styling to h2 text and adjusted `textAlign` to center to match figma designs.

### Reason for changes: To match figma designs