### PR TITLE
1352 Logo component refactor

### DIFF
--- a/products/statement-generator/src/components-layout/AppFooter.tsx
+++ b/products/statement-generator/src/components-layout/AppFooter.tsx
@@ -162,7 +162,7 @@ const AppFooter: React.FC = () => {
     <footer className={classes.footerWrapper}>
       <div className={`${classes.appFooter} ${utilityClasses.widePage}`}>
         <div className={classes.leftContainer}>
-          <Logo footer />
+          <Logo />
         </div>
 
         <div className={classes.rightContainer}>

--- a/products/statement-generator/src/components-layout/AppFooter.tsx
+++ b/products/statement-generator/src/components-layout/AppFooter.tsx
@@ -162,7 +162,7 @@ const AppFooter: React.FC = () => {
     <footer className={classes.footerWrapper}>
       <div className={`${classes.appFooter} ${utilityClasses.widePage}`}>
         <div className={classes.leftContainer}>
-          <Logo />
+          <Logo imageOnly />
         </div>
 
         <div className={classes.rightContainer}>

--- a/products/statement-generator/src/components-layout/AppHeader.tsx
+++ b/products/statement-generator/src/components-layout/AppHeader.tsx
@@ -160,7 +160,7 @@ const AppHeader = () => {
   return (
     <div className={classes.headerWrapper}>
       <div className={`${classes.appHeader} ${utilityClasses.widePage}`}>
-        <Logo includeText />
+        <Logo />
 
         <div className={classes.rightContainer}>
           <HeaderLink to={AppUrl.Landing}>{t('links.home')}</HeaderLink>

--- a/products/statement-generator/src/components-layout/AppHeader.tsx
+++ b/products/statement-generator/src/components-layout/AppHeader.tsx
@@ -160,7 +160,7 @@ const AppHeader = () => {
   return (
     <div className={classes.headerWrapper}>
       <div className={`${classes.appHeader} ${utilityClasses.widePage}`}>
-        <Logo />
+        <Logo includeText />
 
         <div className={classes.rightContainer}>
           <HeaderLink to={AppUrl.Landing}>{t('links.home')}</HeaderLink>

--- a/products/statement-generator/src/components/Logo.tsx
+++ b/products/statement-generator/src/components/Logo.tsx
@@ -35,24 +35,10 @@ const useStyles = makeStyles<Theme, IUseUtilityStyle>(
 
 interface ILogoComponent {
   theme?: string; // dark, light
-  includeText?: boolean; // is logo located in the footer?
+  imageOnly?: boolean; // include text in logo?
 }
 
-function TextLogo({ theme, includeText }: ILogoComponent) {
-  const classes = useStyles({ pageTheme: theme });
-
-  if (!includeText) {
-    return null;
-  }
-
-  return (
-    <Link to="/" className={classes.logoLink} aria-label="Expunge Assist home">
-      <span>Expunge Assist</span>
-    </Link>
-  );
-}
-
-export default function Logo({ theme, includeText }: ILogoComponent) {
+export default function Logo({ theme, imageOnly }: ILogoComponent) {
   const classes = useStyles({ pageTheme: theme });
 
   const logoIcon = theme === 'dark' ? iconWhite : iconBlack;
@@ -63,7 +49,15 @@ export default function Logo({ theme, includeText }: ILogoComponent) {
         <img src={logoIcon} alt="" />
       </Link>
 
-      <TextLogo theme={theme} includeText={includeText} />
+      {!imageOnly && (
+        <Link
+          to="/"
+          className={classes.logoLink}
+          aria-label="Expunge Assist home"
+        >
+          Expunge Assist
+        </Link>
+      )}
     </div>
   );
 }

--- a/products/statement-generator/src/components/Logo.tsx
+++ b/products/statement-generator/src/components/Logo.tsx
@@ -13,10 +13,6 @@ const useStyles = makeStyles<Theme, IUseUtilityStyle>(
         fontSize: 20,
         maxHeight: ({ footer }: IUseUtilityStyle) => (footer ? '25px' : 'null'),
         marginBottom: ({ footer }: IUseUtilityStyle) => (footer ? 0 : 'null'),
-
-        [breakpoints.down(breakpoints.values.sm)]: {
-          // display: 'none',
-        },
       },
 
       logoLink: {
@@ -28,16 +24,6 @@ const useStyles = makeStyles<Theme, IUseUtilityStyle>(
         color: ({ pageTheme }: IUseUtilityStyle) =>
           pageTheme === 'dark' ? 'white' : palette.common.black,
 
-        // we want the text to be stacked vertically,
-        //  when we are in the footer AND when in mobile view
-        [breakpoints.up(breakpoints.values.sm)]: {
-          '& span + span': {
-            marginLeft: ({ footer }: IUseUtilityStyle) => (footer ? 0 : 8),
-          },
-        },
-
-        flexDirection: ({ footer }: IUseUtilityStyle) =>
-          footer ? 'column' : 'row',
         fontSize: ({ footer }: IUseUtilityStyle) => (footer ? 12 : 'inherit'),
         [breakpoints.down(breakpoints.values.sm)]: {
           flexDirection: 'column',
@@ -49,26 +35,25 @@ const useStyles = makeStyles<Theme, IUseUtilityStyle>(
 
 interface ILogoComponent {
   theme?: string; // dark, light
-  footer?: boolean; // is logo located in the footer?
+  includeText?: boolean; // is logo located in the footer?
 }
 
-function TextLogo({ theme, footer }: ILogoComponent) {
-  const classes = useStyles({ pageTheme: theme, footer });
+function TextLogo({ theme, includeText }: ILogoComponent) {
+  const classes = useStyles({ pageTheme: theme });
 
-  if (footer) {
+  if (!includeText) {
     return null;
   }
 
   return (
     <Link to="/" className={classes.logoLink} aria-label="Expunge Assist home">
-      <span>Expunge</span>
-      <span>Assist</span>
+      <span>Expunge Assist</span>
     </Link>
   );
 }
 
-export default function Logo({ theme, footer }: ILogoComponent) {
-  const classes = useStyles({ pageTheme: theme, footer });
+export default function Logo({ theme, includeText }: ILogoComponent) {
+  const classes = useStyles({ pageTheme: theme });
 
   const logoIcon = theme === 'dark' ? iconWhite : iconBlack;
 
@@ -78,7 +63,7 @@ export default function Logo({ theme, footer }: ILogoComponent) {
         <img src={logoIcon} alt="" />
       </Link>
 
-      <TextLogo theme={theme} footer={footer} />
+      <TextLogo theme={theme} includeText={includeText} />
     </div>
   );
 }

--- a/products/statement-generator/src/components/Logo.tsx
+++ b/products/statement-generator/src/components/Logo.tsx
@@ -10,8 +10,10 @@ const useStyles = makeStyles<Theme, IUseUtilityStyle>(({ palette, spacing }) =>
     logoContainer: {
       display: 'flex',
       fontSize: 20,
-      maxHeight: ({ footer }: IUseUtilityStyle) => (footer ? '25px' : 'null'),
-      marginBottom: ({ footer }: IUseUtilityStyle) => (footer ? 0 : 'null'),
+      maxHeight: ({ imageOnly }: IUseUtilityStyle) =>
+        imageOnly ? '25px' : 'null',
+      marginBottom: ({ imageOnly }: IUseUtilityStyle) =>
+        imageOnly ? 0 : 'null',
     },
 
     logoLink: {
@@ -22,7 +24,8 @@ const useStyles = makeStyles<Theme, IUseUtilityStyle>(({ palette, spacing }) =>
       fontWeight: 800,
       color: ({ pageTheme }: IUseUtilityStyle) =>
         pageTheme === 'dark' ? 'white' : palette.common.black,
-      fontSize: ({ footer }: IUseUtilityStyle) => (footer ? 12 : 'inherit'),
+      fontSize: ({ imageOnly }: IUseUtilityStyle) =>
+        imageOnly ? 12 : 'inherit',
     },
   })
 );

--- a/products/statement-generator/src/components/Logo.tsx
+++ b/products/statement-generator/src/components/Logo.tsx
@@ -5,32 +5,26 @@ import { Theme, makeStyles, createStyles } from '@material-ui/core';
 import iconBlack from 'assets/iconBlack.svg';
 import iconWhite from 'assets/iconWhite.svg';
 
-const useStyles = makeStyles<Theme, IUseUtilityStyle>(
-  ({ palette, breakpoints, spacing }) =>
-    createStyles({
-      logoContainer: {
-        display: 'flex',
-        fontSize: 20,
-        maxHeight: ({ footer }: IUseUtilityStyle) => (footer ? '25px' : 'null'),
-        marginBottom: ({ footer }: IUseUtilityStyle) => (footer ? 0 : 'null'),
-      },
+const useStyles = makeStyles<Theme, IUseUtilityStyle>(({ palette, spacing }) =>
+  createStyles({
+    logoContainer: {
+      display: 'flex',
+      fontSize: 20,
+      maxHeight: ({ footer }: IUseUtilityStyle) => (footer ? '25px' : 'null'),
+      marginBottom: ({ footer }: IUseUtilityStyle) => (footer ? 0 : 'null'),
+    },
 
-      logoLink: {
-        textDecoration: 'none',
-        display: 'flex',
-        marginLeft: spacing(2),
-        textTransform: 'uppercase',
-        fontWeight: 800,
-        color: ({ pageTheme }: IUseUtilityStyle) =>
-          pageTheme === 'dark' ? 'white' : palette.common.black,
-
-        fontSize: ({ footer }: IUseUtilityStyle) => (footer ? 12 : 'inherit'),
-        [breakpoints.down(breakpoints.values.sm)]: {
-          flexDirection: 'column',
-          fontSize: 12,
-        },
-      },
-    })
+    logoLink: {
+      textDecoration: 'none',
+      display: 'flex',
+      marginLeft: spacing(2),
+      textTransform: 'uppercase',
+      fontWeight: 800,
+      color: ({ pageTheme }: IUseUtilityStyle) =>
+        pageTheme === 'dark' ? 'white' : palette.common.black,
+      fontSize: ({ footer }: IUseUtilityStyle) => (footer ? 12 : 'inherit'),
+    },
+  })
 );
 
 interface ILogoComponent {

--- a/products/statement-generator/src/global.d.ts
+++ b/products/statement-generator/src/global.d.ts
@@ -1,5 +1,5 @@
 //
 interface IUseUtilityStyle {
   pageTheme?: string;
-  footer?: boolean;
+  imageOnly?: boolean;
 }


### PR DESCRIPTION
Fixes #1352 

### Changes Made
- Refactor the Logo component to accept an `imageOnly` prop and render the appropriate logo(s) based on the prop value.
- Remove unnecessary code from previous designs where text logo appeared in footer as well

### Reason for Changes
- The current implementation of the Logo component used in the header & footer separates the logic for text and image logos. There's separate conditional rendering for each. This can lead to potential inconsistencies and make maintenance more difficult.
- Text logo no longer included in footer so we can get rid of that code

### Action Items
- [x] change base branch to `dev`
- [x] review PR files to guarantee ONLY relevant code is present
- [x] add https://github.com/hackforla/expunge-assist/labels/ready%20for%20dev%20lead label
