### PR TITLE
1681 - move closing line

### DIFF
--- a/products/statement-generator/src/helpers/statementGenerators.ts
+++ b/products/statement-generator/src/helpers/statementGenerators.ts
@@ -198,7 +198,7 @@ export function generateWhy(formState: IStepState): string {
     return '';
   }
 
-  return `Getting my record cleared would have a major impact on my life. ${clearRecordWhy} ${clearRecordHow} Thank you for considering my case.`;
+  return `Getting my record cleared would have a major impact on my life. ${clearRecordWhy} ${clearRecordHow}`;
 }
 
 /**

--- a/products/statement-generator/src/pages/PreviewPage.tsx
+++ b/products/statement-generator/src/pages/PreviewPage.tsx
@@ -9,7 +9,6 @@ import { AppUrl } from 'contexts/RoutingProps';
 import RoutingContext from 'contexts/RoutingContext';
 import { getPreviewConfig, getPreviewStatement } from 'helpers/previewHelper';
 import { getSectionTitle } from 'helpers/i18nHelper';
-import { generateClosing } from 'helpers/statementGenerators';
 
 function PreviewPage() {
   const { formState, updateStepToForm } = useContext(FormStateContext);
@@ -37,7 +36,6 @@ function PreviewPage() {
   // hacky implementation to generate the heading & closing statement here
   //  because it does not have a unique page to be generated via a preview
   useEffect(() => {
-    console.log(currentStep)
     if (currentStep === AppUrl.IntroductionPreview) {
       const displayDate = new Date().toLocaleDateString('en-US', {
         year: 'numeric',

--- a/products/statement-generator/src/pages/PreviewPage.tsx
+++ b/products/statement-generator/src/pages/PreviewPage.tsx
@@ -9,6 +9,7 @@ import { AppUrl } from 'contexts/RoutingProps';
 import RoutingContext from 'contexts/RoutingContext';
 import { getPreviewConfig, getPreviewStatement } from 'helpers/previewHelper';
 import { getSectionTitle } from 'helpers/i18nHelper';
+import { generateClosing } from 'helpers/statementGenerators';
 
 function PreviewPage() {
   const { formState, updateStepToForm } = useContext(FormStateContext);
@@ -36,6 +37,7 @@ function PreviewPage() {
   // hacky implementation to generate the heading & closing statement here
   //  because it does not have a unique page to be generated via a preview
   useEffect(() => {
+    console.log(currentStep)
     if (currentStep === AppUrl.IntroductionPreview) {
       const displayDate = new Date().toLocaleDateString('en-US', {
         year: 'numeric',
@@ -47,7 +49,7 @@ function PreviewPage() {
         statements: {
           ...formState.statements,
           heading: `${displayDate},\n\nTo whom it may concern,`,
-          closing: `Sincerely,\n${formState.introduction.fullName}`,
+          closing: `Thank you for considering my case.\n\nSincerely,\n${formState.introduction.fullName}`,
         },
       });
     }


### PR DESCRIPTION
Fixes #1681 

### Changes Made
- moved the generation of the `Thank you for considering my case.` line to the Closing section. 

### Reason for Changes
- Bonnie request

### Screenshots (if needed)
#### before
<img width="575" alt="Screenshot 2025-03-16 at 4 25 42 PM" src="https://github.com/user-attachments/assets/960bfbb6-2f40-41a2-8cb1-3d4a309d3fcd" />


#### after
<img width="571" alt="Screenshot 2025-03-16 at 4 27 27 PM" src="https://github.com/user-attachments/assets/cf456fc4-3be5-4c31-9224-70ebf5c118be" />


### Action Items
- [x] change base branch to `dev`
- [ ] review PR files to guarantee ONLY relevant code is present
- [ ] add https://github.com/hackforla/expunge-assist/labels/ready%20for%20dev%20lead label
