### PR TITLE
Account for multiple page PDF download #1688

### DIFF
--- a/products/statement-generator/src/pages-form/Download.tsx
+++ b/products/statement-generator/src/pages-form/Download.tsx
@@ -136,8 +136,28 @@ export default function Download({ onDownloadAgreementCheck }: IDownload) {
   const handleClickPDF = () => {
     const doc = new jsPDF('p', 'mm', 'letter');
     doc.setFontSize(12);
-    const lines = doc.splitTextToSize(finalStatement, 170);
-    doc.text(20, 50, lines);
+
+    const marginLeft = 20;
+    const marginTop = 30;
+    const marginBottom = 30;
+    const maxWidth = 170;
+    const lineHeight = 6;
+    const pageHeight = doc.internal.pageSize.height;
+
+    let y = marginTop;
+
+    const lines = doc.splitTextToSize(finalStatement, maxWidth);
+
+    // account for spillover onto multiple pages
+    lines.forEach((line: string) => {
+      if (y + lineHeight > pageHeight - marginBottom) {
+        doc.addPage();
+        y = 30;
+      }
+      doc.text(marginLeft, y, line);
+      y += lineHeight;
+    });
+
     doc.save('MyPersonalStatement.pdf');
   };
 


### PR DESCRIPTION
Fixes #1688

### Changes Made
- Made jspdf settings more clear with variable names
- Accounted for letters that are > 1 page

### Reason for Changes
PDF download was cutting off letters longer than 1 page

### Action Items
- [x] change base branch to `dev`
- [x] review PR files to guarantee ONLY relevant code is present
- [x] add https://github.com/hackforla/expunge-assist/labels/ready%20for%20dev%20lead label
