### PR TITLE
updated key terms on the letter generator pop-ups following figma design

### DIFF
--- a/products/statement-generator/public/locales/en/translation.json
+++ b/products/statement-generator/public/locales/en/translation.json
@@ -89,19 +89,19 @@
   "affirmation_popup": {
     "step2": {
       "titleText": "Thank you",
-      "description": "Now that you have introduced yourself, it’s time to start writing your letter."
+      "description": "Now that you have introduced yourself, it’s time to start writing your declaration."
     },
     "step3": {
       "titleText": "Well done",
-      "description": "Now that you have completed the first section of your letter, it’s time to write the next section."
+      "description": "Now that you have completed the first section of your declaration, it’s time to write the next section."
     },
     "step4": {
       "titleText": "Keep going",
-      "description": "Now that you have completed the second section of your letter, it’s time to write the final section."
+      "description": "Now that you have completed the second section of your declaration, it’s time to write the final section."
     },
     "step5": {
       "titleText": "Almost done",
-      "description": "Just one more step. Next, you can preview your entire letter and make changes.\n\nWhen you are done, email or download a copy of your letter."
+      "description": "Just one more step. Next, you can preview your entire declaration and make changes.\n\nWhen you are done, email or download a copy of your declaration."
     },
     "done": {
       "titleText": "Return home?",


### PR DESCRIPTION
Fixes #1702 

### Changes Made
Update key terms on 4 different letter generator popups following figma design file.

### Reason for Changes
Needed to update key terms to match the rest of the site.

### Screenshots (if needed)
#### before
![image](https://github.com/user-attachments/assets/0e8e7d99-4ec5-4328-afce-fdb104e77e40)
![image](https://github.com/user-attachments/assets/648dfc96-b5cb-4f4e-823c-97e70c816971)
![image](https://github.com/user-attachments/assets/3a4216fa-6768-483f-a16f-8d044164a065)
![image](https://github.com/user-attachments/assets/4af68a10-2dad-46d7-be2c-a4b3cfef682d)



#### after
![image](https://github.com/user-attachments/assets/f70ad4bd-9cf9-450d-bf01-2c71de3f5c32)
![image](https://github.com/user-attachments/assets/ab0eac19-9dd9-47b4-b431-9faedc12ac38)
![image](https://github.com/user-attachments/assets/af7a2beb-5f73-4340-84b4-3f9c73806ac0)
![image](https://github.com/user-attachments/assets/bb2a864f-f57a-4057-a34a-781f31b5647f)


### Action Items
- [ ] change base branch to `dev`
- [ ] review PR files to guarantee ONLY relevant code is present
- [ ] add https://github.com/hackforla/expunge-assist/labels/ready%20for%20dev%20lead label
