### PR TITLE
added new line height to Terms of Use page

### DIFF
--- a/products/statement-generator/src/pages/TermsOfUse.tsx
+++ b/products/statement-generator/src/pages/TermsOfUse.tsx
@@ -2,22 +2,38 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import ContentContainer from 'components-layout/ContentContainer';
+import { createStyles, makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    text: {
+      lineHeight: 1.5,
+    },
+  })
+);
 
 function TermsOfUse() {
   const { t } = useTranslation();
+  const classes = useStyles();
 
   return (
     <ContentContainer>
       <h2>{t('links.terms_of_use')}</h2>
       <h3>{t('terms_of_use_page.generator_heading')}</h3>
-      <p>{t('terms_of_use_page.generator_description')}</p>
+      <p className={classes.text}>
+        {t('terms_of_use_page.generator_description')}
+      </p>
 
       <h3>{t('terms_of_use_page.scope_heading')}</h3>
-      <p>{t('terms_of_use_page.scope_description')}</p>
+      <p className={classes.text}>{t('terms_of_use_page.scope_description')}</p>
 
       <h3>{t('terms_of_use_page.contributions_heading')}</h3>
-      <p>{t('terms_of_use_page.contributions_description')}</p>
-      <p>{t('terms_of_use_page.liability_description')}</p>
+      <p className={classes.text}>
+        {t('terms_of_use_page.contributions_description')}
+      </p>
+      <p className={classes.text}>
+        {t('terms_of_use_page.liability_description')}
+      </p>
     </ContentContainer>
   );
 }


### PR DESCRIPTION
Fixes #1686 

### Changes Made
Updated the line height of the paragraphs on the Terms of Use page to match the styles on the FAQ page.

### Reason for Changes
Needed to align Terms of Use styles with FAQ styles.

### Screenshots (if needed)
#### before
![image](https://github.com/user-attachments/assets/69503566-b071-4f98-b241-4a42652a7b4f)



#### after
![image](https://github.com/user-attachments/assets/a40d2c89-7fd6-41b2-8b45-6f45d77b8277)


### Action Items
- [ ] change base branch to `dev`
- [ ] review PR files to guarantee ONLY relevant code is present
- [ ] add https://github.com/hackforla/expunge-assist/labels/ready%20for%20dev%20lead label
