### PR TITLE
1788 update involvement copy

### DIFF
--- a/products/statement-generator/public/locales/en/translation.json
+++ b/products/statement-generator/public/locales/en/translation.json
@@ -124,6 +124,15 @@
     "finalize": "My declaration letter",
     "completed": "Completed"
   },
+  "sections_helper_text": {
+    "job": "Current job(s) full-time, part-time, or self-employed",
+    "unemployment": "Looking for work and/or difficulty finding work",
+    "self_improvement": "Counseling, musical/art therapies, health and fitness, or treatment programs",
+    "education": "School, college, or certification",
+    "parenting": "Raising a child or children",
+    "community_service": "Volunteer work at a community organization",
+    "something_else": "Anything else you want to include"
+  },
   "introduction_form": {
     "fullName_input_label": "What is your full name?",
     "fullName_input_placeholder": "Firstname Lastname",
@@ -132,7 +141,7 @@
     "isVeteran_label": "Are you a veteran of the United States of America?"
   },
   "involvement_form": {
-    "checkboxgroup_label": "What have you been involved with since your conviction?\n\nCheck all that apply:",
+    "checkboxgroup_label": "What have you been involved with since your conviction?\n\nCheck all that apply. You will be able to add more details later.",
     "none_above": "None of the above"
   },
   "job_form": {

--- a/products/statement-generator/src/components/Checkbox.tsx
+++ b/products/statement-generator/src/components/Checkbox.tsx
@@ -1,16 +1,11 @@
 import React from 'react';
 import { makeStyles, createStyles, Theme } from '@material-ui/core';
-import { teal } from '@material-ui/core/colors';
 import Box from '@material-ui/core/Box';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
 import FormHelperText from '@material-ui/core/FormHelperText';
 
-interface ICheckboxStyle {
-  theme?: string;
-}
-
-const useStyles = makeStyles<Theme, ICheckboxStyle>(({ palette }) =>
+const useStyles = makeStyles<Theme>(({ palette }) =>
   createStyles({
     root: {
       display: 'grid',
@@ -18,30 +13,19 @@ const useStyles = makeStyles<Theme, ICheckboxStyle>(({ palette }) =>
 
       '& .MuiFormControlLabel-root': {
         marginLeft: 0, // Undo default -11px styling
-      },
+        color: palette.primary.darker,
 
-      '& .MuiCheckbox-root': {
-        padding: '0px 8px 0px 0px', // 8px right padding on checkbox
-        color: ({ theme }) => {
-          switch (theme) {
-            case 'teal':
-              return teal.A400;
-            case 'black':
-            default:
-              return palette.common.black;
-          }
-        },
+        '& .MuiCheckbox-root': {
+          padding: '0px 8px 0px 0px', // 8px right padding on checkbox
 
-        // hacky because the component is adding the colorSecondary for some reason
-        '&.MuiCheckbox-colorSecondary.Mui-checked': {
-          color: ({ theme }) => {
-            switch (theme) {
-              case 'teal':
-                return teal.A400;
-              case 'black':
-              default:
-                return palette.common.black;
-            }
+          // MUI v4 checkboxes default to secondary
+          '&.MuiCheckbox-colorSecondary': {
+            color: palette.primary.darker,
+            opacity: 0.3,
+            '&.Mui-checked': {
+              color: palette.success.main,
+              opacity: 1,
+            },
           },
         },
       },
@@ -50,6 +34,9 @@ const useStyles = makeStyles<Theme, ICheckboxStyle>(({ palette }) =>
         marginTop: 0,
         marginLeft: 32, // Padding to align with checkbox label
         fontSize: '0.875rem',
+        lineHeight: '1rem',
+        color: palette.primary.darker,
+        opacity: 0.75,
       },
     },
   })
@@ -69,15 +56,14 @@ const InnerCheckbox = React.forwardRef<HTMLInputElement, IInnerCheckboxProps>(
 
 interface IWrapperCheckboxProps extends IInnerCheckboxProps {
   label: string;
-  useTeal?: boolean;
   helperText?: string;
 }
 
 const CheckboxLabels = React.forwardRef<
   HTMLInputElement,
   IWrapperCheckboxProps
->(({ label, helperText = '', checked, onChange, id, useTeal = false }, ref) => {
-  const classes = useStyles({ theme: useTeal ? 'teal' : 'black' });
+>(({ label, helperText = '', checked, onChange, id }, ref) => {
+  const classes = useStyles();
   return (
     <Box className={classes.root}>
       <FormControlLabel

--- a/products/statement-generator/src/components/Checkbox.tsx
+++ b/products/statement-generator/src/components/Checkbox.tsx
@@ -3,6 +3,7 @@ import { makeStyles, createStyles, Theme } from '@material-ui/core';
 import { teal } from '@material-ui/core/colors';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
+import FormHelperText from '@material-ui/core/FormHelperText';
 
 interface ICheckboxStyle {
   theme?: string;
@@ -61,24 +62,27 @@ const InnerCheckbox = React.forwardRef<HTMLInputElement, IInnerCheckboxProps>(
 
 interface IWrapperCheckboxProps extends IInnerCheckboxProps {
   label: string;
+  helperText?: string;
 }
 
 const CheckboxLabels = React.forwardRef<
   HTMLInputElement,
   IWrapperCheckboxProps
->(({ label, checked, onChange, id, useTeal = false }, ref) => (
-  <FormControlLabel
-    control={
-      <InnerCheckbox
-        useTeal={useTeal}
-        id={id}
-        checked={checked}
-        onChange={onChange}
-        ref={ref}
-      />
-    }
-    label={label}
-  />
+>(({ label, helperText = '', checked, onChange, id, useTeal = false }, ref) => (
+  <>
+    <FormControlLabel
+      control={
+        <InnerCheckbox
+          useTeal={useTeal}
+          id={id}
+          checked={checked}
+          onChange={onChange}
+          ref={ref}
+        />
+      }
+      label={label}
+    />
+    {helperText && <FormHelperText>{helperText}</FormHelperText>}
+  </>
 ));
-
 export default CheckboxLabels;

--- a/products/statement-generator/src/components/Checkbox.tsx
+++ b/products/statement-generator/src/components/Checkbox.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { makeStyles, createStyles, Theme } from '@material-ui/core';
 import { teal } from '@material-ui/core/colors';
+import Box from '@material-ui/core/Box';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
 import FormHelperText from '@material-ui/core/FormHelperText';
@@ -12,18 +13,15 @@ interface ICheckboxStyle {
 const useStyles = makeStyles<Theme, ICheckboxStyle>(({ palette }) =>
   createStyles({
     root: {
-      color: ({ theme }) => {
-        switch (theme) {
-          case 'teal':
-            return teal.A400;
-          case 'black':
-          default:
-            return palette.common.black;
-        }
+      display: 'grid',
+      gridGap: 4,
+
+      '& .MuiFormControlLabel-root': {
+        marginLeft: 0, // Undo default -11px styling
       },
 
-      // hacky because the component is adding the colorSecondary for some reason
-      '&.MuiCheckbox-colorSecondary.Mui-checked': {
+      '& .MuiCheckbox-root': {
+        padding: '0px 8px 0px 0px', // 8px right padding on checkbox
         color: ({ theme }) => {
           switch (theme) {
             case 'teal':
@@ -33,6 +31,25 @@ const useStyles = makeStyles<Theme, ICheckboxStyle>(({ palette }) =>
               return palette.common.black;
           }
         },
+
+        // hacky because the component is adding the colorSecondary for some reason
+        '&.MuiCheckbox-colorSecondary.Mui-checked': {
+          color: ({ theme }) => {
+            switch (theme) {
+              case 'teal':
+                return teal.A400;
+              case 'black':
+              default:
+                return palette.common.black;
+            }
+          },
+        },
+      },
+
+      '& .MuiFormHelperText-root': {
+        marginTop: 0,
+        marginLeft: 32, // Padding to align with checkbox label
+        fontSize: '0.875rem',
       },
     },
   })
@@ -42,47 +59,40 @@ interface IInnerCheckboxProps extends CheckboxProps {
   checked: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   id?: string;
-  useTeal?: boolean;
 }
 
 const InnerCheckbox = React.forwardRef<HTMLInputElement, IInnerCheckboxProps>(
-  ({ checked, onChange, id, useTeal }, ref) => {
-    const classes = useStyles({ theme: useTeal ? 'teal' : 'black' });
-    return (
-      <Checkbox
-        classes={classes}
-        checked={checked}
-        onChange={onChange}
-        id={id}
-        inputRef={ref}
-      />
-    );
-  }
+  ({ checked, onChange, id }, ref) => (
+    <Checkbox checked={checked} onChange={onChange} id={id} inputRef={ref} />
+  )
 );
 
 interface IWrapperCheckboxProps extends IInnerCheckboxProps {
   label: string;
+  useTeal?: boolean;
   helperText?: string;
 }
 
 const CheckboxLabels = React.forwardRef<
   HTMLInputElement,
   IWrapperCheckboxProps
->(({ label, helperText = '', checked, onChange, id, useTeal = false }, ref) => (
-  <>
-    <FormControlLabel
-      control={
-        <InnerCheckbox
-          useTeal={useTeal}
-          id={id}
-          checked={checked}
-          onChange={onChange}
-          ref={ref}
-        />
-      }
-      label={label}
-    />
-    {helperText && <FormHelperText>{helperText}</FormHelperText>}
-  </>
-));
+>(({ label, helperText = '', checked, onChange, id, useTeal = false }, ref) => {
+  const classes = useStyles({ theme: useTeal ? 'teal' : 'black' });
+  return (
+    <Box className={classes.root}>
+      <FormControlLabel
+        control={
+          <InnerCheckbox
+            id={id}
+            checked={checked}
+            onChange={onChange}
+            ref={ref}
+          />
+        }
+        label={label}
+      />
+      {helperText && <FormHelperText>{helperText}</FormHelperText>}
+    </Box>
+  );
+});
 export default CheckboxLabels;

--- a/products/statement-generator/src/pages-form/InvolvementInitialFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementInitialFlow.tsx
@@ -84,6 +84,7 @@ function InvolvementInitialFlow() {
             checked={isJobChecked}
             onChange={onCheckboxChange}
             label={t('sections.job')}
+            helperText={t('sections_helper_text.job')}
           />
           <Checkbox
             useTeal
@@ -91,6 +92,7 @@ function InvolvementInitialFlow() {
             checked={isUnemploymentChecked}
             onChange={onCheckboxChange}
             label={t('sections.unemployment')}
+            helperText={t('sections_helper_text.unemployment')}
           />
           <Checkbox
             useTeal
@@ -98,6 +100,7 @@ function InvolvementInitialFlow() {
             checked={isRecoveryChecked}
             onChange={onCheckboxChange}
             label={t('sections.self_improvement')}
+            helperText={t('sections_helper_text.self_improvement')}
           />
 
           <Checkbox
@@ -106,6 +109,7 @@ function InvolvementInitialFlow() {
             checked={isSchoolChecked}
             onChange={onCheckboxChange}
             label={t('sections.education')}
+            helperText={t('sections_helper_text.education')}
           />
 
           <Checkbox
@@ -114,6 +118,7 @@ function InvolvementInitialFlow() {
             checked={isParentingChecked}
             onChange={onCheckboxChange}
             label={t('sections.parenting')}
+            helperText={t('sections_helper_text.parenting')}
           />
 
           <Checkbox
@@ -122,6 +127,7 @@ function InvolvementInitialFlow() {
             checked={isCommunityChecked}
             onChange={onCheckboxChange}
             label={t('sections.community_service')}
+            helperText={t('sections_helper_text.community_service')}
           />
 
           <Checkbox
@@ -130,6 +136,7 @@ function InvolvementInitialFlow() {
             checked={isSomethingElseChecked}
             onChange={onCheckboxChange}
             label={t('sections.something_else')}
+            helperText={t('sections_helper_text.something_else')}
           />
         </FormGroup>
       </FormControl>

--- a/products/statement-generator/src/pages-form/InvolvementInitialFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementInitialFlow.tsx
@@ -15,10 +15,10 @@ const useStyles = makeStyles<Theme>(({ palette }) =>
     checkboxGroup: {
       gap: 24,
       '& .MuiFormLabel-root': {
-        color: palette.common.black,
+        color: palette.primary.darker,
       },
       '& .MuiFormLabel-root.Mui-focused': {
-        color: palette.common.black,
+        color: palette.primary.darker,
       },
       '& .MuiFormGroup-root': {
         gap: 16,
@@ -79,7 +79,6 @@ function InvolvementInitialFlow() {
         </FormLabel>
         <FormGroup id="involvement-checkboxes">
           <Checkbox
-            useTeal
             id="isJobChecked"
             checked={isJobChecked}
             onChange={onCheckboxChange}
@@ -87,7 +86,6 @@ function InvolvementInitialFlow() {
             helperText={t('sections_helper_text.job')}
           />
           <Checkbox
-            useTeal
             id="isUnemploymentChecked"
             checked={isUnemploymentChecked}
             onChange={onCheckboxChange}
@@ -95,43 +93,34 @@ function InvolvementInitialFlow() {
             helperText={t('sections_helper_text.unemployment')}
           />
           <Checkbox
-            useTeal
             id="isRecoveryChecked"
             checked={isRecoveryChecked}
             onChange={onCheckboxChange}
             label={t('sections.self_improvement')}
             helperText={t('sections_helper_text.self_improvement')}
           />
-
           <Checkbox
-            useTeal
             id="isSchoolChecked"
             checked={isSchoolChecked}
             onChange={onCheckboxChange}
             label={t('sections.education')}
             helperText={t('sections_helper_text.education')}
           />
-
           <Checkbox
-            useTeal
             id="isParentingChecked"
             checked={isParentingChecked}
             onChange={onCheckboxChange}
             label={t('sections.parenting')}
             helperText={t('sections_helper_text.parenting')}
           />
-
           <Checkbox
-            useTeal
             id="isCommunityChecked"
             checked={isCommunityChecked}
             onChange={onCheckboxChange}
             label={t('sections.community_service')}
             helperText={t('sections_helper_text.community_service')}
           />
-
           <Checkbox
-            useTeal
             id="isSomethingElseChecked"
             checked={isSomethingElseChecked}
             onChange={onCheckboxChange}

--- a/products/statement-generator/src/pages-form/InvolvementInitialFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementInitialFlow.tsx
@@ -10,18 +10,18 @@ import FormStateContext from 'contexts/FormStateContext';
 import Checkbox from 'components/Checkbox';
 import FormFlowContainer from 'components-layout/FormFlowContainer';
 
-const useStyles = makeStyles<Theme>(({ palette, spacing }) =>
+const useStyles = makeStyles<Theme>(({ palette }) =>
   createStyles({
     checkboxGroup: {
+      gap: 24,
       '& .MuiFormLabel-root': {
         color: palette.common.black,
       },
       '& .MuiFormLabel-root.Mui-focused': {
         color: palette.common.black,
       },
-
-      '& .MuiFormLabel-root + .MuiFormGroup-root': {
-        marginTop: spacing(1),
+      '& .MuiFormGroup-root': {
+        gap: 16,
       },
     },
   })


### PR DESCRIPTION
Fixes #1788

### Changes Made
Note: Apologies for the essay here -- I'm new to React and MUI and wanted to be clear about what I was trying to do. Very much looking forward to critical feedback. There are a few changes to make the page match the provided Figma that may have gone beyond the scope of this issue... for the most part, I separated those out into later commits that I can roll back. The things that I think may be borderline are marked with (?). 

- Updated `en/translations.json`
    - Added `sections_helper_text` section and populated it with the "involvement option" explanatory text copy
    - `checkboxgroup_label` text with new copy
- Updated `Checkbox.tsx`
    - For `CheckboxLabels`: 
        - Added optional `helperText` prop to pass in sub-labels
        - Added a  `FormHelperText` component that is conditionally generated if `helperText` is not default (`''`)
        - Wrapped the existing `FormControlLabel` and new `FormHelperText` in a `Box`
        - Added `classes` definition and usage in `Box` instantiation
        - (?) Removed the `useTeal` prop
    - For `InnerCheckbox`:
        - Removed the `classes` definition and usage in the `Checkbox` call  
        - Removed the `useTeal` prop
    - For `useStyles`: 
        - Updated to target `Box`
        - (?) Replaced `marginTop` spacing scheme with making `Box` display as a grid with a defined `gridGap` that matched figma
        - Set `FormControlLabel` `marginLeft` to 0 to undo a default of -11
        - (?) Removed `teal` usage to favor using the palette
        - (?) Set `FormControlLabel` color to the palette dark purple to match Figma
        - Removed `Checkbox` padding other than right padding so helperText would be flush with the label
        - (?) Updated color settings of `Checkbox` to match the Figma (light purple when inactive, cyan when active) using the palette, added comment that I think addresses the previous comment question
        - Added formatting for the helper text to match the Figma
- Updated `InvolvementInitialFlow.tsx`
    -  Added helperText prop to all `Checkbox` components
    - (?) Removed `useTeal` prop from all `CheckBox` components
    - For `useStyles`:
        - (?) Updated text color settings to use the palette dark purple to match Figma
        - (?) Replaced `marginTop` spacing scheme with flexbox gaps

### Reason for Changes
- Copy changes and helper text added to improve user clarity on the meaning of the options (issue focus)
- Optional `helperText` prop added to `Checkbox.tsx` to enable reusable inclusion of helper text
- `useTeal` prop removed because it seemed (to me) to be obsolete after switch to theme usage.
- Spacing formatting changes (gap, gridGap) made to simplify component spacing once helper text was added
- Colors updated so that the modified component and page would match the provided design reference.

### Screenshots (if needed)


#### before
<details>
<summary>None selected</summary>
<img width="916" height="972" alt="Screenshot from 2025-08-14 15-02-29" src="https://github.com/user-attachments/assets/a66921f4-339f-4c54-821a-72ef6455e0ef" />
</details>
<details>
<summary>All selected</summary>
<img width="916" height="972" alt="Screenshot from 2025-08-14 15-02-37" src="https://github.com/user-attachments/assets/6df8a6d8-55b1-42ee-8569-91f68112785c" />
</details>
<details>
<summary>All selected mobile</summary>
<img width="502" height="991" alt="Screenshot from 2025-08-14 15-03-03" src="https://github.com/user-attachments/assets/5c883c1b-5307-4e52-ad66-276ae13772b8" />
</details>

#### after
<details>
<summary>None selected</summary>
<img width="916" height="972" alt="Screenshot from 2025-08-14 15-01-49" src="https://github.com/user-attachments/assets/4f621cad-9ff9-4903-ae2a-7961dc220051" />
</details>
<details>
<summary>All selected</summary>
<img width="916" height="972" alt="Screenshot from 2025-08-14 15-01-56" src="https://github.com/user-attachments/assets/16228d87-9908-4cae-987f-aa98e6619295" />
</details>
<details>
<summary>All selected mobile</summary>
<img width="502" height="991" alt="Screenshot from 2025-08-14 15-03-45" src="https://github.com/user-attachments/assets/fa589a37-7d92-4cef-827b-286fda115593" />
</details>

### Action Items
- [ ] change base branch to `dev`
- [ ] review PR files to guarantee ONLY relevant code is present
- [ ] add https://github.com/hackforla/expunge-assist/labels/ready%20for%20dev%20lead label
