### PR TITLE
updated key terms on welcome and advice pages

### DIFF
--- a/products/statement-generator/public/locales/en/translation.json
+++ b/products/statement-generator/public/locales/en/translation.json
@@ -65,10 +65,10 @@
   },
   "welcome_page": {
     "titleText": "Welcome",
-    "description": "This tool will guide you through writing your declaration letter. You can preview your letter and make changes at the end of each section."
+    "description": "This tool will guide you through writing your declaration. You can preview your declaration and make changes at the end of each section."
   },
   "advice_page": {
-    "header": "Advice for a successful declaration letter",
+    "header": "Advice for a successful declaration",
     "point1": {
       "content": "Remember to avoid using informal language, such as abbreviations, slang and profanity:",
       "no": "Dude, gig, DOJ",


### PR DESCRIPTION
updated key terms on welcome and advice pages to be consistent as shown in the figma file

Fixes #1689 

### Changes Made
Updated declaration letter to declaration in welcome screen and changed declaration letter to declaration in advice page.

### Reason for Changes
Needed to update terms to be consistent with the rest of the site.

### Screenshots (if needed)
#### before


#### after


### Action Items
- [ ] change base branch to `dev`
- [ ] review PR files to guarantee ONLY relevant code is present
- [ ] add https://github.com/hackforla/expunge-assist/labels/ready%20for%20dev%20lead label
