### PR TITLE
Update "Involvement: Employment" page to add "other jobs" option (#1701)

### DIFF
--- a/products/statement-generator/.env.example
+++ b/products/statement-generator/.env.example
@@ -18,7 +18,7 @@ REACT_APP_COMPANY_NAME=Cool Company
 REACT_APP_JOB_TITLE=Big Boss
 REACT_APP_JOB_DESCRIPTION=I make the decisions on what the biggest cake should be.
 REACT_APP_IS_OTHER_JOB_CHECKED=True
-REACT_APP_OTHER_JOB_DESCRIPION=I work at a volunteer tech non-profit.
+REACT_APP_OTHER_JOB_DESCRIPTION=I work at a volunteer tech non-profit.
 
 
 REACT_APP_NAME=Addicts Anonymous

--- a/products/statement-generator/.env.example
+++ b/products/statement-generator/.env.example
@@ -17,6 +17,8 @@ REACT_APP_SERVICE_DESCRIPTION=I check cakes for poison. It is a very serious job
 REACT_APP_COMPANY_NAME=Cool Company
 REACT_APP_JOB_TITLE=Big Boss
 REACT_APP_JOB_DESCRIPTION=I make the decisions on what the biggest cake should be.
+REACT_APP_IS_OTHER_JOB_CHECKED=True
+REACT_APP_OTHER_JOB_DESCRIPION=I work at a volunteer tech non-profit.
 
 
 REACT_APP_NAME=Addicts Anonymous

--- a/products/statement-generator/public/locales/en/translation.json
+++ b/products/statement-generator/public/locales/en/translation.json
@@ -141,7 +141,10 @@
     "jobTitle_input_label": "What is your current job title?",
     "jobTitle_input_placeholder": "Job title",
     "jobDescription_input_label": "What do you do at this job? How has your role at work impacted your life for the better?\n(2-3 complete sentences)",
-    "jobDescription_input_placeholder": ""
+    "jobDescription_input_placeholder": "",
+    "otherJob_label": "Do you have another job (or jobs) you would like to talk about?",
+    "otherJobDescription_input_label": "Add information about your job (or jobs). Be sure to include the company's name and your job title. (3-5 complete sentences)",
+    "otherJobDescription_input_placeholder": ""
   },
   "something_else_form": {
     "activityName_input_label": "What else have you been involved in?",

--- a/products/statement-generator/src/contexts/FormStateProps.ts
+++ b/products/statement-generator/src/contexts/FormStateProps.ts
@@ -37,6 +37,8 @@ export const defaultStepState = {
     companyName: '',
     jobTitle: '',
     jobDescription: '',
+    isOtherJobChecked: '',
+    otherJobDescription: '',
   },
   communityServiceState: {
     organizationName: '',
@@ -107,6 +109,8 @@ export interface IInvolvementJobState {
   companyName: string;
   jobTitle: string;
   jobDescription: string;
+  isOtherJobChecked: string;
+  otherJobDescription: string;
 }
 // step 2b
 export interface ICommunityServiceState {
@@ -182,6 +186,8 @@ export const sampleStepState = {
     companyName: process.env.REACT_APP_COMPANY_NAME,
     jobTitle: process.env.REACT_APP_JOB_TITLE,
     jobDescription: process.env.REACT_APP_JOB_DESCRIPTION,
+    isOtherJobChecked: process.env.REACT_APP_IS_OTHER_JOB_CHECKED,
+    otherJobDescription: process.env.REACT_APP_OTHER_JOB_DESCRIPTION,
   },
   communityServiceState: {
     organizationName: process.env.REACT_APP_ORGANIZATION_NAME,

--- a/products/statement-generator/src/helpers/statementGenerators.ts
+++ b/products/statement-generator/src/helpers/statementGenerators.ts
@@ -29,7 +29,12 @@ export function generateIntroduction(formState: IStepState): string {
  */
 export function generateInvolvementJob(formState: IStepState): string {
   const {
-    involvementJobState: { companyName, jobTitle, jobDescription },
+    involvementJobState: {
+      companyName,
+      jobTitle,
+      jobDescription,
+      otherJobDescription,
+    },
   } = formState;
 
   if (!formState.involvement.isJobChecked) {
@@ -43,7 +48,13 @@ export function generateInvolvementJob(formState: IStepState): string {
   // Determine the correct article "a" or "an" based on the first letter of the jobTitle
   const article = generateArticle(jobTitle);
 
-  return `I have been working at ${companyName} as ${article} ${jobTitle}. At ${companyName}, ${jobDescription}`;
+  let result = `I have been working at ${companyName} as ${article} ${jobTitle}. At ${companyName}, ${jobDescription}`;
+
+  if (otherJobDescription) {
+    result += ` ${otherJobDescription}`;
+  }
+
+  return result;
 }
 
 /**

--- a/products/statement-generator/src/pages-form/InvolvementJobFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementJobFlow.tsx
@@ -121,7 +121,7 @@ function InvolvementJobFlow() {
           placeholder={t('job_form.otherJobDescription_input_placeholder')}
           handleChange={onInputChange}
           defaultValue={otherJobDescription}
-          rows={3}
+          rows={4}
         />
       )}
     </FormFlowContainer>

--- a/products/statement-generator/src/pages-form/InvolvementJobFlow.tsx
+++ b/products/statement-generator/src/pages-form/InvolvementJobFlow.tsx
@@ -5,6 +5,7 @@ import FormStateContext from 'contexts/FormStateContext';
 
 import Input from 'components/Input';
 import Textarea from 'components/Textarea';
+import RadioGroup from 'components/RadioGroup';
 import FormFlowContainer from 'components-layout/FormFlowContainer';
 
 import {
@@ -20,13 +21,22 @@ function InvolvementJobFlow() {
     companyName,
     jobTitle,
     jobDescription,
+    isOtherJobChecked,
+    otherJobDescription,
   } = formState.involvementJobState;
 
   const companyNameValid = companyName !== '';
   const jobTitleValid = jobTitle !== '';
-  const jobDescriptionValid = jobDescription !== '';
+  const jobDescriptionValid = /\w/.test(jobDescription || ''); // Check if contains any word character
+  const otherJobDescriptionValid =
+    isOtherJobChecked === t('button.no') ||
+    (isOtherJobChecked === t('button.yes') &&
+      /\w/.test(otherJobDescription || '')); // Check if contains any word character
   const isNextDisabled =
-    !companyNameValid || !jobTitleValid || !jobDescriptionValid;
+    !companyNameValid ||
+    !jobTitleValid ||
+    !jobDescriptionValid ||
+    !otherJobDescriptionValid;
 
   const onInputChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
     const { id, value } = evt.currentTarget;
@@ -34,7 +44,7 @@ function InvolvementJobFlow() {
 
     if (id === 'companyName' || id === 'jobTitle') {
       formattedValue = capitalizeEachWord(value);
-    } else if (id === 'jobDescription') {
+    } else if (id === 'jobDescription' || id === 'otherJobDescription') {
       formattedValue = capitalizeSentences(value);
     }
 
@@ -43,6 +53,17 @@ function InvolvementJobFlow() {
     const changes = { [id]: formattedValue };
     updateStepToForm({
       involvementJobState: { ...formState.involvementJobState, ...changes },
+    });
+  };
+
+  const onOtherJobChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
+    const isChecked = evt.currentTarget.value === t('button.yes');
+    updateStepToForm({
+      involvementJobState: {
+        ...formState.involvementJobState,
+        isOtherJobChecked: evt.currentTarget.value,
+        ...(isChecked ? {} : { otherJobDescription: '' }),
+      },
     });
   };
 
@@ -84,6 +105,25 @@ function InvolvementJobFlow() {
         defaultValue={jobDescription}
         rows={3}
       />
+
+      <RadioGroup
+        id="otherJob"
+        label={t('job_form.otherJob_label')}
+        choices={[t('button.yes'), t('button.no')]}
+        value={isOtherJobChecked}
+        handleChange={onOtherJobChange}
+      />
+
+      {isOtherJobChecked === t('button.yes') && (
+        <Textarea
+          id="otherJobDescription"
+          label={t('job_form.otherJobDescription_input_label')}
+          placeholder={t('job_form.otherJobDescription_input_placeholder')}
+          handleChange={onInputChange}
+          defaultValue={otherJobDescription}
+          rows={3}
+        />
+      )}
     </FormFlowContainer>
   );
 }


### PR DESCRIPTION
Fixes #1701

### Changes Made
- Added copy for additional job button label and textbox in `en/translation.json`
- Added "additional job" button and dynamically appearing "additional job description" textbox in `InvolvementJobFlow.tsx`
- Added additional job selected and description in `FormStateProps.ts` and statement update in `statementGenerators.ts`
- In `InvolvementJobFlow.tsx`, also updated the logic for Text Boxes to block "Next" when text is first entered and then deleted
    - Before this update (which made a to regex checking for any word characters), if text is entered in a textbox, that textbox would permanently stop blocking Next because the `capitalizeSentences` call adds a period to the text that can't be deleted by the user.
- Added additional example environment variables for the new "additional job description" fields. 

### Reason for Changes
- Overall change gives users the option to have the Statement Generator include additional jobs as part of their social involvements
- Textbox validation update helps ensure that blank text is not accidentally used in the statement generator.

### Screenshots (if needed)
#### before
<details>
<summary>Previous page on entry</summary>
<img width="1100" height="1169" alt="old_on_entry" src="https://github.com/user-attachments/assets/fbc04157-0422-4679-ac19-ef1bf1d8560a" />
</details>
<details>
<summary>Previous filled page</summary>
<img width="1100" height="1169" alt="old_filled" src="https://github.com/user-attachments/assets/90d4d3ec-897e-40dc-9955-ab61ff747ffc" />
</details>
<details>
<summary>Previous Statement</summary>
<img width="1100" height="1169" alt="old_statement" src="https://github.com/user-attachments/assets/ab93b7f7-c66d-479f-9206-50309a435d10" />
</details>

#### after
<details>
<summary>New page on entry</summary>
<img width="1100" height="1169" alt="updated_on_entry" src="https://github.com/user-attachments/assets/db3a88d5-b7ce-4563-9951-bf28874fa115" />
</details>
<details>
<summary>New page filled with no "other job" selection</summary>
<img width="1100" height="1169" alt="updated_unchecked_others_filled" src="https://github.com/user-attachments/assets/459e07e9-f417-4891-bf4c-50ed5882e568" />
</details>
<details>
<summary>New page filled with "other job" selected as No</summary>
<img width="1100" height="1169" alt="updated_wo_other_all_filled" src="https://github.com/user-attachments/assets/3b2bcb43-4a71-4685-b008-5e2304f0beba" />
</details>
<details>
<summary>New page filled with "other job" selected as Yes but description empty</summary>
<img width="1100" height="1169" alt="updated_w_other_unfilled" src="https://github.com/user-attachments/assets/4c284af9-6be4-41cc-9496-32023e99ac34" />
</details>
<details>
<summary>New page filled with "other job" selected as Yes and description filled</summary>
<img width="1100" height="1169" alt="updated_w_other_all_filled" src="https://github.com/user-attachments/assets/8bc11f99-5c94-4cf0-87f9-dee6f62f2ca1" />
</details>
<details>
<summary>New summary without other job description</summary>
<img width="1100" height="1169" alt="updated_statement_wo_other" src="https://github.com/user-attachments/assets/21ec5e55-4c03-4f58-a7a6-93a338cabcec" />
</details>
<details>
<summary>New summary with other job description</summary>
<img width="1100" height="1169" alt="updated_statement_w_other" src="https://github.com/user-attachments/assets/b1b10115-83ff-4878-a83a-a7c346589fd2" />
</details>


### Action Items
- [ ] change base branch to `dev`
- [ ] review PR files to guarantee ONLY relevant code is present
- [ ] add https://github.com/hackforla/expunge-assist/labels/ready%20for%20dev%20lead label
